### PR TITLE
Use a more accurate method to determine endpoints on a request span.

### DIFF
--- a/opentracing/src/opentracing_request_instrumentor.h
+++ b/opentracing/src/opentracing_request_instrumentor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <opentracing/tracer.h>
+#include <chrono>
 #include <exception>
 #include <memory>
 #include "opentracing_conf.h"
@@ -38,7 +39,9 @@ class OpenTracingRequestInstrumentor {
   std::unique_ptr<opentracing::Span> request_span_;
   std::unique_ptr<opentracing::Span> span_;
 
-  void on_exit_block();
+  void on_exit_block(std::chrono::steady_clock::time_point finish_timestamp =
+                         std::chrono::steady_clock::now());
+
   void set_request_span_context();
 };
 }  // namespace ngx_opentracing

--- a/opentracing/src/utility.cpp
+++ b/opentracing/src/utility.cpp
@@ -28,4 +28,15 @@ ngx_str_t to_lower_ngx_str(ngx_pool_t *pool, const std::string &s) {
                  [](char c) { return std::tolower(c); });
   return result;
 }
+
+//------------------------------------------------------------------------------
+// to_system_timestamp
+//------------------------------------------------------------------------------
+std::chrono::system_clock::time_point to_system_timestamp(
+    time_t epoch_seconds, ngx_msec_t epoch_milliseconds) {
+  auto epoch_duration = std::chrono::seconds{epoch_seconds} +
+                        std::chrono::milliseconds{epoch_milliseconds};
+  return std::chrono::system_clock::from_time_t(std::time_t{0}) +
+         epoch_duration;
+}
 }  // namespace ngx_opentracing

--- a/opentracing/src/utility.h
+++ b/opentracing/src/utility.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <string>
 
 extern "C" {
@@ -30,6 +31,14 @@ ngx_str_t to_ngx_str(ngx_pool_t *pool, const std::string &s);
 //------------------------------------------------------------------------------
 // Convert a std::string to an ngx_str_t and transforms it to lowercase.
 ngx_str_t to_lower_ngx_str(ngx_pool_t *pool, const std::string &s);
+
+//------------------------------------------------------------------------------
+// to_system_timestamp
+//------------------------------------------------------------------------------
+// Converts the epoch denoted by epoch_seconds, epoch_milliseconds to an
+// std::chrono::system_clock::time_point duration from the epoch.
+std::chrono::system_clock::time_point to_system_timestamp(
+    time_t epoch_seconds, ngx_msec_t epoch_milliseconds);
 
 //------------------------------------------------------------------------------
 // for_each


### PR DESCRIPTION
Follows the same logic as NGINX's [$request_time](http://nginx.org/en/docs/http/ngx_http_log_module.html#var_request_time).