### PR TITLE
Add option to disable trusting incoming spans

### DIFF
--- a/doc/Directives.md
+++ b/doc/Directives.md
@@ -32,6 +32,14 @@ of the span for an NGINX request.
 Sets the [operation name](https://github.com/opentracing/specification/blob/master/specification.md#start-a-new-span)
 of the span for an NGINX location block.
 
+### `opentracing_trust_incoming_span`
+
+- **syntax** `opentracing_trust_incoming_span on|off`
+- **default**: `on`
+- **context**: `http`, `server`, `location`
+
+Enables or disables using OpenTracing spans from incoming requests as parent for created ones. Might be disabled for security reasons.
+
 ### `opentracing_tag`
 
 - **syntax** `opentracing_tag <key> <value>`

--- a/opentracing/src/ngx_http_opentracing_module.cpp
+++ b/opentracing/src/ngx_http_opentracing_module.cpp
@@ -155,6 +155,7 @@ static void *create_opentracing_loc_conf(ngx_conf_t *conf) {
 
   loc_conf->enable = NGX_CONF_UNSET;
   loc_conf->enable_locations = NGX_CONF_UNSET;
+  loc_conf->trust_incoming_span = NGX_CONF_UNSET;
 
   return loc_conf;
 }
@@ -177,6 +178,8 @@ static char *merge_opentracing_loc_conf(ngx_conf_t *, void *parent,
   if (prev->loc_operation_name_script.is_valid() &&
       !conf->loc_operation_name_script.is_valid())
     conf->loc_operation_name_script = prev->loc_operation_name_script;
+
+  ngx_conf_merge_value(conf->trust_incoming_span, prev->trust_incoming_span, 1);
 
   // Create a new array that joins `prev->tags` and `conf->tags`. Since tags
   // are set consecutively and setting a tag with the same key as a previous
@@ -234,6 +237,11 @@ static ngx_command_t opentracing_commands[] = {
          NGX_CONF_TAKE1,
      set_opentracing_location_operation_name, NGX_HTTP_LOC_CONF_OFFSET, 0,
      nullptr},
+    {ngx_string("opentracing_trust_incoming_span"),
+     NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
+         NGX_CONF_TAKE1,
+     ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(opentracing_loc_conf_t, trust_incoming_span), nullptr},
     {ngx_string("opentracing_tag"),
      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
          NGX_CONF_TAKE2,

--- a/opentracing/src/opentracing_conf.h
+++ b/opentracing/src/opentracing_conf.h
@@ -24,6 +24,7 @@ struct opentracing_loc_conf_t {
   ngx_flag_t enable_locations;
   NgxScript operation_name_script;
   NgxScript loc_operation_name_script;
+  ngx_flag_t trust_incoming_span;
   ngx_array_t *tags;
 };
 }  // namespace ngx_opentracing

--- a/opentracing/src/opentracing_request_instrumentor.cpp
+++ b/opentracing/src/opentracing_request_instrumentor.cpp
@@ -80,7 +80,11 @@ OpenTracingRequestInstrumentor::OpenTracingRequestInstrumentor(
       ngx_http_get_module_main_conf(request_, ngx_http_opentracing_module));
   auto tracer = opentracing::Tracer::Global();
   if (!tracer) throw InstrumentationFailure{};
-  auto parent_span_context = extract_span_context(*tracer, request_);
+
+  std::unique_ptr<opentracing::SpanContext> parent_span_context = nullptr;
+  if (loc_conf_->trust_incoming_span) {
+    parent_span_context = extract_span_context(*tracer, request_);
+  }
 
   ngx_log_debug1(NGX_LOG_DEBUG_HTTP, request_->connection->log, 0,
                  "starting opentracing request span for %p", request_);


### PR DESCRIPTION
It might be a security weakness to simply always trust and extract parent span information from all incoming requests. Depending on the way how NGINX is deployed the header in the request could be spoofed by clients or used to exploit vulnerabilities in the parser. I feel more comformtable exposing NGINX instances  which I know do not even *try* to parse user-supplied information that might be unsafe.