### PR TITLE
Add support for dynamic opentracing op name

### DIFF
--- a/opentracing/src/opentracing_request_instrumentor.cpp
+++ b/opentracing/src/opentracing_request_instrumentor.cpp
@@ -181,6 +181,15 @@ void OpenTracingRequestInstrumentor::on_log_request() {
   add_status_tags(request_, *request_span_);
   add_script_tags(main_conf_->tags, request_, *request_span_);
 
+  // When opentracing_operation_name points to a variable and it can be
+  // initialized or modified at any phase of the request, so set the
+  // span operation name at request exit phase, which will take the latest
+  // value of the variable pointed to opentracing_operation_name directive
+  auto core_loc_conf = static_cast<ngx_http_core_loc_conf_t *>(
+      ngx_http_get_module_loc_conf(request_, ngx_http_core_module));
+  request_span_->SetOperationName(
+      get_request_operation_name(request_, core_loc_conf, loc_conf_));
+
   request_span_->Finish({opentracing::FinishTimestamp{finish_timestamp}});
 }
 }  // namespace ngx_opentracing


### PR DESCRIPTION
The nginx  variable value can be changed at any phase of
the request. In such cases opentracing_operation_name
directive is not taking the latest value.
opentracing_operation_name directive is executed during
request init phase, so when its points to a variable X,
and if there is any update to X after init then the change
is not reflecting to opentracing_operation_name.

Testing:
 Nginx Conf Details:
  Declared the variable X in nginx conf and initialised it
  to 'abcd'.Declared the opentracing_operation_name directive
  and pointed it to $X
 Case 1:
  Updated the X to '1234' through other nginx modules (openresty)
  Jaeger UI shows operation name for the request is 1234
 Case 2:
  No change to value of X Jaeger UI shows operation name for
  the request is abcd