### PR TITLE
Add default `http.host` tag

### DIFF
--- a/opentracing/src/ngx_http_opentracing_module.cpp
+++ b/opentracing/src/ngx_http_opentracing_module.cpp
@@ -38,7 +38,8 @@ const std::pair<ngx_str_t, ngx_str_t> kDefaultOpenTracingTags[] = {
     {ngx_string("nginx.worker_pid"), ngx_string("$pid")},
     {ngx_string("peer.address"), ngx_string("$remote_addr:$remote_port")},
     {ngx_string("http.method"), ngx_string("$request_method")},
-    {ngx_string("http.url"), ngx_string("$scheme://$http_host$request_uri")}};
+    {ngx_string("http.url"), ngx_string("$scheme://$http_host$request_uri")},
+    {ngx_string("http.host"), ngx_string("$http_host")}};
 
 //------------------------------------------------------------------------------
 // add_opentracing_tag


### PR DESCRIPTION
Some tracing backends such as jaeger [don't support](https://github.com/jaegertracing/jaeger/issues/684) wildcard queries. This tag also is part of the multi-vendor opencensus tracing [http specification](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#attributes) and makes it possible to query for traces by a specific vhost. Zipkin also [does not support](https://github.com/openzipkin/zipkin/issues/723) wildcard queries.