### PR TITLE
Zipkin Sampling

### DIFF
--- a/zipkin/doc/Directives.md
+++ b/zipkin/doc/Directives.md
@@ -21,3 +21,11 @@ Specifies the host to use when uploading traces.
 - **context**: `http`
 
 Specifies the port to use when uploading traces.
+
+### `zipkin_sample_rate`
+
+- **syntax** `zipkin_sample_rate <rate>`
+- **default**: `1.0`
+- **context**: `http`
+
+Specifies the probability of a span being sampled and reported.

--- a/zipkin/src/ngx_http_zipkin_module.cpp
+++ b/zipkin/src/ngx_http_zipkin_module.cpp
@@ -25,6 +25,7 @@ struct zipkin_main_conf_t {
   ngx_str_t collector_host;
   ngx_str_t collector_port;
   ngx_str_t service_name;
+  ngx_str_t sample_rate;
 };
 
 //------------------------------------------------------------------------------
@@ -44,6 +45,11 @@ static ngx_int_t zipkin_init_worker(ngx_cycle_t *cycle) {
     tracer_options.service_name = to_string(main_conf->service_name);
   else
     tracer_options.service_name = "nginx";
+  if (main_conf->sample_rate.data)
+    tracer_options.sample_rate = std::stod(to_string(main_conf->sample_rate));
+  else
+    tracer_options.sample_rate = 1.0;
+  
   auto tracer = makeZipkinOtTracer(tracer_options);
   if (!tracer) {
     ngx_log_error(NGX_LOG_ERR, cycle->log, 0, "Failed to create Zipkin tracer");
@@ -91,7 +97,10 @@ static ngx_command_t zipkin_commands[] = {
      offsetof(zipkin_main_conf_t, collector_host), nullptr},
     {ngx_string("zipkin_collector_port"), NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
      ngx_conf_set_str_slot, NGX_HTTP_MAIN_CONF_OFFSET,
-     offsetof(zipkin_main_conf_t, collector_port), nullptr}};
+     offsetof(zipkin_main_conf_t, collector_port), nullptr},
+    {ngx_string("zipkin_sample_rate"), NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_str_slot, NGX_HTTP_MAIN_CONF_OFFSET,
+     offsetof(zipkin_main_conf_t, sample_rate), nullptr}};
 
 //------------------------------------------------------------------------------
 // ngx_http_zipkin_module


### PR DESCRIPTION
This builds upon work in https://github.com/rnburn/zipkin-cpp-opentracing/pull/20 to provide probabilistic sampling when using zipkin.

* `zipkin_sample_rate` configuration option added. It should be a number between 0 and 1 and determines how likely a span is to be sampled.
* Sampling defaults to `1` (always sample) in the event of no incoming sampling decision.