### PR TITLE
Produce binary modules for nginx of Debian stable

### DIFF
--- a/ci/build_module_binaries.sh
+++ b/ci/build_module_binaries.sh
@@ -3,7 +3,7 @@
 set -e
 
 export OPENTRACING_VERSION=1.4.0
-NGINX_VERSIONS=(1.15.0 1.14.0 1.13.12 1.12.2)
+NGINX_VERSIONS=(1.15.0 1.14.0 1.13.12 1.12.2 1.10.3)
 
 # Compile for a portable cpu architecture
 export CFLAGS="-march=x86-64 -fPIC"


### PR DESCRIPTION
That would hopefully enable people running the [nginx 1.10.3 of the stable version of Debian](https://packages.debian.org/stable/nginx) to use this module out of the box.