### PR TITLE
Adds an image and example for tracing OpenResty Lua code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ jobs:
       - checkout
       - run:
           command: docker build -t opentracing/nginx-opentracing .
+  openresty_docker_image:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          command: docker build -t opentracing/openresty -f Dockerfile-openresty .
   module_binaries:
     docker:
       - image: ubuntu:18.04
@@ -67,4 +73,5 @@ workflows:
               only: /^v[0-9]+(\.[0-9]+)*$/
       - system_testing
       - docker_image
+      - openresty_docker_image
       - module_binaries

--- a/Dockerfile-openresty
+++ b/Dockerfile-openresty
@@ -45,7 +45,7 @@ ARG RESTY_CONFIG_OPTIONS="\
     "
 ARG RESTY_CONFIG_OPTIONS_MORE=""
 ARG OPENTRACING_CPP_VERSION="v1.4.0"
-ARG LUA_BRIDGE_TRACER_VERSION="5360d34d56a4e83b14684d8c59ff84b59d1c77da"
+ARG LUA_BRIDGE_TRACER_VERSION="9213e1b0c23a0d028093895d290c705680fbf4c5"
 ARG JAEGER_VERSION="v0.4.1"
 ARG LIGHTSTEP_VERSION="v0.7.1"
 ARG ZIPKIN_VERSION="v0.4.0"
@@ -102,7 +102,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
   && rm -rf opentracing-cpp \
 ### Build bridge tracer
   && cd /tmp \
-  && git clone https://github.com/rnburn/lua-bridge-tracer.git \
+  && git clone https://github.com/opentracing/lua-bridge-tracer.git \
   && cd lua-bridge-tracer \
   && git checkout ${LUA_BRIDGE_TRACER_VERSION} \
   && mkdir .build && cd .build \

--- a/Dockerfile-openresty
+++ b/Dockerfile-openresty
@@ -1,0 +1,56 @@
+FROM ubuntu:18.04
+
+ARG OPENTRACING_CPP_VERSION=v1.4.0
+ARG OPENRESTY_VERSION=1.13.6.2
+
+COPY . /src
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+              build-essential \
+              gettext \
+              cmake \
+              git \
+              gnupg2 \
+              software-properties-common \
+              curl \
+              jq \
+              ca-certificates \
+              wget \
+              libpcre3 libpcre3-dev \
+              zlib1g-dev \
+              gcc-8 \
+              g++-8 \
+              libssl-dev \
+              lua5.1-dev \
+### Build opentracing-cpp
+  && cd / \
+  && git clone -b $OPENTRACING_CPP_VERSION https://github.com/opentracing/opentracing-cpp.git \
+  && cd opentracing-cpp \
+  && mkdir .build && cd .build \
+  && cmake -DCMAKE_BUILD_TYPE=Debug \
+           -DBUILD_TESTING=OFF .. \
+  && make && make install \
+### Build bridge tracer
+  && cd / \
+  && git clone https://github.com/rnburn/lua-bridge-tracer.git \
+  && cd lua-bridge-tracer \
+  && mkdir .build && cd .build \
+  && cmake .. \
+  && make && make install \
+### Install tracers
+  && wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v0.4.1/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
+  && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.7.1/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so \
+  && wget -O - https://github.com/rnburn/zipkin-cpp-opentracing/releases/download/v0.4.0/linux-amd64-libzipkin_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libzipkin_opentracing_plugin.so \
+### Build OpenResty
+  && cd /src \
+  && wget -O openresty-${OPENRESTY_VERSION}.tar.gz https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz \
+  && tar zxf openresty-${OPENRESTY_VERSION}.tar.gz \
+  && cd /src/openresty-${OPENRESTY_VERSION} \
+  && ./configure \
+      --with-compat \
+      --add-dynamic-module=/src/opentracing \
+  && make && make install \
+  && ldconfig
+CMD ["/usr/local/openresty/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/Dockerfile-openresty
+++ b/Dockerfile-openresty
@@ -1,56 +1,158 @@
-FROM ubuntu:18.04
+# Dockerfile - Ubuntu Xenial
+# https://github.com/openresty/docker-openresty
 
-ARG OPENTRACING_CPP_VERSION=v1.4.0
-ARG OPENRESTY_VERSION=1.13.6.2
+ARG RESTY_IMAGE_BASE="ubuntu"
+ARG RESTY_IMAGE_TAG="xenial"
+
+FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
+
+# Docker Build Arguments
+ARG RESTY_VERSION="1.13.6.2"
+ARG RESTY_LUAROCKS_VERSION="2.4.4"
+ARG RESTY_OPENSSL_VERSION="1.1.0h"
+ARG RESTY_PCRE_VERSION="8.42"
+ARG RESTY_J="1"
+ARG RESTY_CONFIG_OPTIONS="\
+    --with-file-aio \
+    --with-http_addition_module \
+    --with-http_auth_request_module \
+    --with-http_dav_module \
+    --with-http_flv_module \
+    --with-http_geoip_module=dynamic \
+    --with-http_gunzip_module \
+    --with-http_gzip_static_module \
+    --with-http_image_filter_module=dynamic \
+    --with-http_mp4_module \
+    --with-http_random_index_module \
+    --with-http_realip_module \
+    --with-http_secure_link_module \
+    --with-http_slice_module \
+    --with-http_ssl_module \
+    --with-http_stub_status_module \
+    --with-http_sub_module \
+    --with-http_v2_module \
+    --with-http_xslt_module=dynamic \
+    --with-ipv6 \
+    --with-mail \
+    --with-mail_ssl_module \
+    --with-md5-asm \
+    --with-pcre-jit \
+    --with-sha1-asm \
+    --with-stream \
+    --with-stream_ssl_module \
+    --with-threads \
+    --add-dynamic-module=/src/opentracing \
+    "
+ARG RESTY_CONFIG_OPTIONS_MORE=""
+ARG OPENTRACING_CPP_VERSION="v1.4.0"
+ARG LUA_BRIDGE_TRACER_VERSION="5360d34d56a4e83b14684d8c59ff84b59d1c77da"
+
+LABEL resty_version="${RESTY_VERSION}"
+LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
+LABEL resty_openssl_version="${RESTY_OPENSSL_VERSION}"
+LABEL resty_pcre_version="${RESTY_PCRE_VERSION}"
+LABEL resty_config_options="${RESTY_CONFIG_OPTIONS}"
+LABEL resty_config_options_more="${RESTY_CONFIG_OPTIONS_MORE}"
+
+# These are not intended to be user-specified
+ARG _RESTY_CONFIG_DEPS="--with-openssl=/tmp/openssl-${RESTY_OPENSSL_VERSION} --with-pcre=/tmp/pcre-${RESTY_PCRE_VERSION}"
 
 COPY . /src
 
-RUN set -x \
-  && apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y \
-              build-essential \
-              gettext \
-              cmake \
-              git \
-              gnupg2 \
-              software-properties-common \
-              curl \
-              jq \
-              ca-certificates \
-              wget \
-              libpcre3 libpcre3-dev \
-              zlib1g-dev \
-              gcc-8 \
-              g++-8 \
-              libssl-dev \
-              lua5.1-dev \
+
+# 1) Install apt dependencies
+# 2) Download and untar OpenSSL, PCRE, and OpenResty
+# 3) Build OpenResty
+# 4) Cleanup
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        gettext-base \
+        libgd-dev \
+        libgeoip-dev \
+        libncurses5-dev \
+        libperl-dev \
+        libreadline-dev \
+        libxslt1-dev \
+        make \
+        perl \
+        unzip \
+        zlib1g-dev \
+        git \
+        cmake \
+        lua5.1-dev \
+        wget \
 ### Build opentracing-cpp
-  && cd / \
-  && git clone -b $OPENTRACING_CPP_VERSION https://github.com/opentracing/opentracing-cpp.git \
+  && cd /tmp \
+  && git clone -b ${OPENTRACING_CPP_VERSION} https://github.com/opentracing/opentracing-cpp.git \
   && cd opentracing-cpp \
   && mkdir .build && cd .build \
-  && cmake -DCMAKE_BUILD_TYPE=Debug \
+  && cmake -DCMAKE_BUILD_TYPE=Release \
+           -DBUILD_MOCKTRACER=OFF \
+           -DBUILD_STATIC_LIBS=OFF \
            -DBUILD_TESTING=OFF .. \
   && make && make install \
+  && cd /tmp \
+  && rm -rf opentracing-cpp \
 ### Build bridge tracer
-  && cd / \
+  && cd /tmp \
   && git clone https://github.com/rnburn/lua-bridge-tracer.git \
   && cd lua-bridge-tracer \
+  && git checkout ${LUA_BRIDGE_TRACER_VERSION} \
   && mkdir .build && cd .build \
-  && cmake .. \
+  && cmake -DCMAKE_BUILD_TYPE=Release \
+            .. \
   && make && make install \
+  && cd /tmp \
+  && rm -rf lua-bridge-tracer \
 ### Install tracers
   && wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v0.4.1/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
   && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.7.1/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so \
   && wget -O - https://github.com/rnburn/zipkin-cpp-opentracing/releases/download/v0.4.0/linux-amd64-libzipkin_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libzipkin_opentracing_plugin.so \
-### Build OpenResty
-  && cd /src \
-  && wget -O openresty-${OPENRESTY_VERSION}.tar.gz https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz \
-  && tar zxf openresty-${OPENRESTY_VERSION}.tar.gz \
-  && cd /src/openresty-${OPENRESTY_VERSION} \
-  && ./configure \
-      --with-compat \
-      --add-dynamic-module=/src/opentracing \
-  && make && make install \
-  && ldconfig
-CMD ["/usr/local/openresty/nginx/sbin/nginx", "-g", "daemon off;"]
+### Copied from https://github.com/openresty/docker-openresty/blob/master/xenial/Dockerfile
+    && cd /tmp \
+    && curl -fSL https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+    && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+    && curl -fSL https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
+    && tar xzf openresty-${RESTY_VERSION}.tar.gz \
+    && cd /tmp/openresty-${RESTY_VERSION} \
+    && ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_CONFIG_OPTIONS_MORE} \
+    && make -j${RESTY_J} \
+    && make -j${RESTY_J} install \
+    && cd /tmp \
+    && rm -rf \
+        openssl-${RESTY_OPENSSL_VERSION} \
+        openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+        openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
+        pcre-${RESTY_PCRE_VERSION}.tar.gz pcre-${RESTY_PCRE_VERSION} \
+    && curl -fSL https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && cd luarocks-${RESTY_LUAROCKS_VERSION} \
+    && ./configure \
+        --prefix=/usr/local/openresty/luajit \
+        --with-lua=/usr/local/openresty/luajit \
+        --lua-suffix=jit-2.1.0-beta3 \
+        --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1 \
+    && make build \
+    && make install \
+    && cd /tmp \
+    && rm -rf /src \
+    && rm -rf luarocks-${RESTY_LUAROCKS_VERSION} luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+    && ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log \
+    && ldconfig
+
+# Add additional binaries into PATH for convenience
+ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
+
+# Copy nginx configuration files
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.conf /usr/local/nginx/conf/nginx.conf
+ADD https://raw.githubusercontent.com/openresty/docker-openresty/master/nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/Dockerfile-openresty
+++ b/Dockerfile-openresty
@@ -46,6 +46,9 @@ ARG RESTY_CONFIG_OPTIONS="\
 ARG RESTY_CONFIG_OPTIONS_MORE=""
 ARG OPENTRACING_CPP_VERSION="v1.4.0"
 ARG LUA_BRIDGE_TRACER_VERSION="5360d34d56a4e83b14684d8c59ff84b59d1c77da"
+ARG JAEGER_VERSION="v0.4.1"
+ARG LIGHTSTEP_VERSION="v0.7.1"
+ARG ZIPKIN_VERSION="v0.4.0"
 
 LABEL resty_version="${RESTY_VERSION}"
 LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
@@ -109,9 +112,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
   && cd /tmp \
   && rm -rf lua-bridge-tracer \
 ### Install tracers
-  && wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v0.4.1/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
-  && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.7.1/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so \
-  && wget -O - https://github.com/rnburn/zipkin-cpp-opentracing/releases/download/v0.4.0/linux-amd64-libzipkin_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libzipkin_opentracing_plugin.so \
+  && wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
+  && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/${LIGHTSTEP_VERSION}/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so \
+  && wget -O - https://github.com/rnburn/zipkin-cpp-opentracing/releases/download/${ZIPKIN_VERSION}/linux-amd64-libzipkin_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libzipkin_opentracing_plugin.so \
 ### Copied from https://github.com/openresty/docker-openresty/blob/master/xenial/Dockerfile
     && cd /tmp \
     && curl -fSL https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -22,11 +22,19 @@ elif [[ "$1" == "push_docker_image" ]]; then
   echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   VERSION_TAG="`git describe --abbrev=0 --tags`"
   VERSION="${VERSION_TAG/v/}" 
+  # nginx
   docker build -t opentracing/nginx-opentracing .
   docker tag opentracing/nginx-opentracing opentracing/nginx-opentracing:${VERSION}
   docker push opentracing/nginx-opentracing:${VERSION}
   docker tag opentracing/nginx-opentracing opentracing/nginx-opentracing:latest
   docker push opentracing/nginx-opentracing:latest
+
+  # openresty
+  docker build -t opentracing/openresty -f Dockerfile-openresty .
+  docker tag opentracing/openresty opentracing/openresty:${VERSION}
+  docker push opentracing/openresty:${VERSION}
+  docker tag opentracing/openresty opentracing/openresty:latest
+  docker push opentracing/openresty:latest
   exit 0
 elif [[ "$1" == "release" ]]; then
   mkdir -p "${BUILD_DIR}"

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -85,3 +85,7 @@ Variables
 Expands to the a value of the active span context; the last part of the variable
 name is the span context's header converted to lower case with dashes replaced by
 underscores.
+
+### `opentracing_binary_context`
+
+Expands to a binary string representation of the active span.

--- a/example/lua/jaeger/docker-compose.yaml
+++ b/example/lua/jaeger/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: '2'
+services:
+
+  nginx:
+    image: openresty
+    networks:
+      openresty_example:
+        aliases:
+          - nginx
+    volumes:
+      - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+      - ./jaeger-config.json:/etc/jaeger-config.json
+    expose:
+      - "8080"
+    ports:
+      - "8080:8080"
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    environment:
+      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+    networks:
+      openresty_example:
+        aliases:
+          - jaeger
+    expose:
+      - "9411"
+      - "16686"
+    ports:
+      - "9411:9411"
+      - "16686:16686"
+
+networks:
+  openresty_example: {}

--- a/example/lua/jaeger/docker-compose.yaml
+++ b/example/lua/jaeger/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 services:
 
   nginx:
-    image: openresty
+    image: opentracing/openresty
     networks:
       openresty_example:
         aliases:

--- a/example/lua/jaeger/jaeger-config.json
+++ b/example/lua/jaeger/jaeger-config.json
@@ -1,0 +1,12 @@
+{
+  "service_name": "nginx",
+  "diabled": false,
+  "reporter": {
+    "logSpans": true,
+    "localAgentHostPort": "jaeger:6831"
+  },
+  "sampler": {
+    "type": "const",
+    "param": "1"
+  }
+}

--- a/example/lua/jaeger/nginx.conf
+++ b/example/lua/jaeger/nginx.conf
@@ -1,0 +1,26 @@
+load_module modules/ngx_http_opentracing_module.so;
+
+worker_processes  1;
+error_log logs/error.log;
+events {
+    worker_connections 1024;
+}
+http {
+    opentracing on;
+    opentracing_load_tracer /usr/local/lib/libjaegertracing_plugin.so /etc/jaeger-config.json;
+
+    server {
+        listen 8080;
+        location / {
+            default_type text/html;
+            content_by_lua '
+                local bridge_tracer = require("opentracing_bridge_tracer")
+                local tracer = bridge_tracer.new_from_global()
+                local parent_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+                local span = tracer:start_span("lua-hello", {["references"] = {{"child_of", parent_context}}})
+                ngx.say("<p>hello, world</p>")
+                span:finish()
+            ';
+        }
+    }
+}

--- a/example/lua/lightstep/docker-compose.yaml
+++ b/example/lua/lightstep/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+
+  nginx:
+    image: openresty
+    networks:
+      openresty_example:
+        aliases:
+          - nginx
+    volumes:
+      - ./start-nginx.sh:/start-nginx.sh
+      - ./nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
+      - ./lightstep-config.json.in:/lightstep-config.json.in
+    environment:
+      - LIGHTSTEP_ACCESS_TOKEN=${LIGHTSTEP_ACCESS_TOKEN}
+    expose:
+      - "8080"
+    ports:
+      - "8080:8080"
+    entrypoint: ./start-nginx.sh
+
+networks:
+  openresty_example: {}

--- a/example/lua/lightstep/docker-compose.yaml
+++ b/example/lua/lightstep/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 services:
 
   nginx:
-    image: openresty
+    image: opentracing/openresty
     networks:
       openresty_example:
         aliases:

--- a/example/lua/lightstep/lightstep-config.json.in
+++ b/example/lua/lightstep/lightstep-config.json.in
@@ -1,0 +1,4 @@
+{
+  "access_token": "$LIGHTSTEP_ACCESS_TOKEN",
+  "component_name": "nginx"
+}

--- a/example/lua/lightstep/nginx.conf
+++ b/example/lua/lightstep/nginx.conf
@@ -1,0 +1,26 @@
+load_module modules/ngx_http_opentracing_module.so;
+
+worker_processes  1;
+error_log logs/error.log;
+events {
+    worker_connections 1024;
+}
+http {
+    opentracing on;
+  opentracing_load_tracer /usr/local/lib/liblightstep_tracer_plugin.so /etc/lightstep-config.json;
+
+    server {
+        listen 8080;
+        location / {
+            default_type text/html;
+            content_by_lua '
+                local bridge_tracer = require("opentracing_bridge_tracer")
+                local tracer = bridge_tracer.new_from_global()
+                local parent_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+                local span = tracer:start_span("lua-hello", {["references"] = {{"child_of", parent_context}}})
+                ngx.say("<p>hello, world</p>")
+                span:finish()
+            ';
+        }
+    }
+}

--- a/example/lua/lightstep/start-nginx.sh
+++ b/example/lua/lightstep/start-nginx.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+envsubst '\$LIGHTSTEP_ACCESS_TOKEN' < /lightstep-config.json.in > /etc/lightstep-config.json
+/usr/local/openresty/nginx/sbin/nginx -g "daemon off;"

--- a/opentracing/src/opentracing_context.h
+++ b/opentracing/src/opentracing_context.h
@@ -31,6 +31,8 @@ class OpenTracingContext {
 
   ngx_str_t lookup_span_context_value(opentracing::string_view key);
 
+  ngx_str_t get_binary_context() const;
+
  private:
   ngx_http_request_t *request_;
   opentracing_main_conf_t *main_conf_;
@@ -40,7 +42,7 @@ class OpenTracingContext {
   std::unique_ptr<opentracing::Span> request_span_;
   std::unique_ptr<opentracing::Span> span_;
 
-  opentracing::Span &active_span();
+  const opentracing::Span &active_span() const;
 
   void on_exit_block(std::chrono::steady_clock::time_point finish_timestamp =
                          std::chrono::steady_clock::now());

--- a/opentracing/src/opentracing_variable.cpp
+++ b/opentracing/src/opentracing_variable.cpp
@@ -108,8 +108,7 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
 
   auto opentracing_binary_context = to_ngx_str(opentracing_binary_context_variable_name);
   auto opentracing_binary_context_var = ngx_http_add_variable(
-      cf, &opentracing_binary_context,
-      NGX_HTTP_VAR_NOCACHEABLE | NGX_HTTP_VAR_NOHASH);
+      cf, &opentracing_binary_context, NGX_HTTP_VAR_NOCACHEABLE);
   opentracing_binary_context_var->get_handler =
       expand_opentracing_binary_context_variable;
   opentracing_binary_context_var->data = 0;

--- a/opentracing/src/opentracing_variable.cpp
+++ b/opentracing/src/opentracing_variable.cpp
@@ -24,6 +24,12 @@ const opentracing::string_view opentracing_context_variable_name{
     "opentracing_context_"};
 
 //------------------------------------------------------------------------------
+// opentracing_binary_context_variable_name
+//------------------------------------------------------------------------------
+static const opentracing::string_view opentracing_binary_context_variable_name{
+    "opentracing_binary_context"};
+
+//------------------------------------------------------------------------------
 // expand_opentracing_context
 //------------------------------------------------------------------------------
 // Extracts the key specified by the variable's suffix and expands to the
@@ -62,6 +68,34 @@ static ngx_int_t expand_opentracing_context_variable(
 }
 
 //------------------------------------------------------------------------------
+// expand_opentracing_binary_context_variable
+//------------------------------------------------------------------------------
+static ngx_int_t expand_opentracing_binary_context_variable(
+    ngx_http_request_t* request, ngx_http_variable_value_t* variable_value,
+    uintptr_t data) noexcept try {
+
+  auto context = get_opentracing_context(request);
+  if (context == nullptr) {
+    throw std::runtime_error{"no OpenTracingContext attached to request"};
+  }
+  auto binary_context = context->get_binary_context();
+  variable_value->len = binary_context.len;
+  variable_value->valid = 1;
+  variable_value->no_cacheable = 1;
+  variable_value->not_found = 0;
+  variable_value->data = binary_context.data;
+
+  return NGX_OK;
+} catch (const std::exception& e) {
+  ngx_log_error(NGX_LOG_ERR, request->connection->log, 0,
+                "failed to expand %s"
+                " for request %p: %s",
+                opentracing_context_variable_name.data(), request, e.what());
+  return NGX_ERROR;
+}
+
+
+//------------------------------------------------------------------------------
 // add_variables
 //------------------------------------------------------------------------------
 ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
@@ -71,6 +105,14 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
       NGX_HTTP_VAR_NOCACHEABLE | NGX_HTTP_VAR_NOHASH | NGX_HTTP_VAR_PREFIX);
   opentracing_context_var->get_handler = expand_opentracing_context_variable;
   opentracing_context_var->data = 0;
+
+  auto opentracing_binary_context = to_ngx_str(opentracing_binary_context_variable_name);
+  auto opentracing_binary_context_var = ngx_http_add_variable(
+      cf, &opentracing_binary_context,
+      NGX_HTTP_VAR_NOCACHEABLE | NGX_HTTP_VAR_NOHASH);
+  opentracing_binary_context_var->get_handler =
+      expand_opentracing_binary_context_variable;
+  opentracing_binary_context_var->data = 0;
 
   return NGX_OK;
 }


### PR DESCRIPTION
This PR sets up the `opentracing/openresty` docker image that includes libraries to allow tracing Lua code. It also adds example for tracing Lua.