### PR TITLE
Change examples to use date.

### DIFF
--- a/example/trivial/jaeger/go/src/hello-backend/server.go
+++ b/example/trivial/jaeger/go/src/hello-backend/server.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"flag"
-	"fmt"
-  "time"
-  "log"
 	opentracing "github.com/opentracing/opentracing-go"
-  "github.com/uber/jaeger-client-go"
-  "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/config"
+	"log"
 	"net/http"
+	"time"
 )
 
 const (
@@ -19,13 +18,10 @@ const (
 	traceID128Bit = true
 )
 
-var collectorHost = flag.String("collector_host", "localhost", "Host for Zipkin Collector")
-var collectorPort = flag.String("collector_port", "6831", "Port for Zipkin Collector")
+var collectorHost = flag.String("collector_host", "localhost", "Host for Jaeger Collector")
+var collectorPort = flag.String("collector_port", "6831", "Port for Jaeger Collector")
 
 func handler(w http.ResponseWriter, r *http.Request) {
-  for k, v := range r.Header {
-    fmt.Fprintf(w, "Header field %q, Value %q\n", k, v)
-  }
 	wireContext, _ := opentracing.GlobalTracer().Extract(
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(r.Header))
@@ -33,33 +29,34 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		"/",
 		opentracing.ChildOf(wireContext))
 	defer span.Finish()
-	fmt.Fprintf(w, "Hello, World!")
+	tm := time.Now().Format(time.RFC1123)
+	w.Write([]byte("The time is " + tm))
 }
 
 func main() {
 	flag.Parse()
-    cfg := config.Configuration{
-    Sampler: &config.SamplerConfig{
-        Type:  "const",
-        Param: 1,
-    },
-    Reporter: &config.ReporterConfig{
-        LocalAgentHostPort: *collectorHost + ":" + *collectorPort,
-        LogSpans:            true,
-        BufferFlushInterval: 1 * time.Second,
-    },
-    }
-    closer, err := cfg.InitGlobalTracer(
-        "backend",
-        config.Logger(jaeger.StdLogger),
-    )
+	cfg := config.Configuration{
+		Sampler: &config.SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+		Reporter: &config.ReporterConfig{
+			LocalAgentHostPort:  *collectorHost + ":" + *collectorPort,
+			LogSpans:            true,
+			BufferFlushInterval: 1 * time.Second,
+		},
+	}
+	closer, err := cfg.InitGlobalTracer(
+		"backend",
+		config.Logger(jaeger.StdLogger),
+	)
 
 	if err != nil {
 		log.Printf("Could not initialize jaeger tracer: %s", err.Error())
 		return
 	}
 
-  defer closer.Close()
+	defer closer.Close()
 
 	http.HandleFunc("/", handler)
 	http.ListenAndServe(":9001", nil)

--- a/example/trivial/ubuntu-x86_64/go/src/hello-backend/server.go
+++ b/example/trivial/ubuntu-x86_64/go/src/hello-backend/server.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"flag"
-	"fmt"
-  "time"
-  "log"
 	opentracing "github.com/opentracing/opentracing-go"
-  "github.com/uber/jaeger-client-go"
-  "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/config"
+	"log"
 	"net/http"
+	"time"
 )
 
 const (
@@ -19,13 +18,10 @@ const (
 	traceID128Bit = true
 )
 
-var collectorHost = flag.String("collector_host", "localhost", "Host for Zipkin Collector")
-var collectorPort = flag.String("collector_port", "6831", "Port for Zipkin Collector")
+var collectorHost = flag.String("collector_host", "localhost", "Host for Jaeger Collector")
+var collectorPort = flag.String("collector_port", "6831", "Port for Jaeger Collector")
 
 func handler(w http.ResponseWriter, r *http.Request) {
-  for k, v := range r.Header {
-    fmt.Fprintf(w, "Header field %q, Value %q\n", k, v)
-  }
 	wireContext, _ := opentracing.GlobalTracer().Extract(
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(r.Header))
@@ -33,33 +29,34 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		"/",
 		opentracing.ChildOf(wireContext))
 	defer span.Finish()
-	fmt.Fprintf(w, "Hello, World!")
+	tm := time.Now().Format(time.RFC1123)
+	w.Write([]byte("The time is " + tm))
 }
 
 func main() {
 	flag.Parse()
-    cfg := config.Configuration{
-    Sampler: &config.SamplerConfig{
-        Type:  "const",
-        Param: 1,
-    },
-    Reporter: &config.ReporterConfig{
-        LocalAgentHostPort: *collectorHost + ":" + *collectorPort,
-        LogSpans:            true,
-        BufferFlushInterval: 1 * time.Second,
-    },
-    }
-    closer, err := cfg.InitGlobalTracer(
-        "backend",
-        config.Logger(jaeger.StdLogger),
-    )
+	cfg := config.Configuration{
+		Sampler: &config.SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+		Reporter: &config.ReporterConfig{
+			LocalAgentHostPort:  *collectorHost + ":" + *collectorPort,
+			LogSpans:            true,
+			BufferFlushInterval: 1 * time.Second,
+		},
+	}
+	closer, err := cfg.InitGlobalTracer(
+		"backend",
+		config.Logger(jaeger.StdLogger),
+	)
 
 	if err != nil {
 		log.Printf("Could not initialize jaeger tracer: %s", err.Error())
 		return
 	}
 
-  defer closer.Close()
+	defer closer.Close()
 
 	http.HandleFunc("/", handler)
 	http.ListenAndServe(":9001", nil)

--- a/example/trivial/zipkin/go/server.go
+++ b/example/trivial/zipkin/go/server.go
@@ -7,6 +7,7 @@ import (
 	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 	"net/http"
 	"os"
+	"time"
 )
 
 const (
@@ -21,9 +22,6 @@ var collectorHost = flag.String("collector_host", "localhost", "Host for Zipkin 
 var collectorPort = flag.String("collector_port", "9411", "Port for Zipkin Collector")
 
 func handler(w http.ResponseWriter, r *http.Request) {
-  for k, v := range r.Header {
-    fmt.Fprintf(w, "Header field %q, Value %q\n", k, v)
-  }
 	wireContext, _ := opentracing.GlobalTracer().Extract(
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(r.Header))
@@ -31,12 +29,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		"/",
 		opentracing.ChildOf(wireContext))
 	defer span.Finish()
-	fmt.Fprintf(w, "Hello, World!")
+	tm := time.Now().Format(time.RFC1123)
+	w.Write([]byte("The time is " + tm))
 }
 
 func main() {
 	flag.Parse()
-  zipkinHTTPEndpoint := "http://" + *collectorHost + ":" + *collectorPort + "/api/v1/spans"
+	zipkinHTTPEndpoint := "http://" + *collectorHost + ":" + *collectorPort + "/api/v1/spans"
 	collector, err := zipkin.NewHTTPCollector(zipkinHTTPEndpoint)
 	if err != nil {
 		fmt.Printf("unable to create Zipkin HTTP collector: %+v\n", err)


### PR DESCRIPTION
Modifies the trivial examples so that it returns the date instead of a fixed string.

Also, corrects some commenting.