### PR TITLE
Allow opentracing_propagate_context directive at http and server

### DIFF
--- a/opentracing/src/ngx_http_opentracing_module.cpp
+++ b/opentracing/src/ngx_http_opentracing_module.cpp
@@ -215,8 +215,9 @@ static ngx_command_t opentracing_commands[] = {
      ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(opentracing_loc_conf_t, enable_locations), nullptr},
     {ngx_string("opentracing_propagate_context"),
-     NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS, propagate_opentracing_context,
-     NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr},
+     NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
+         NGX_CONF_NOARGS,
+     propagate_opentracing_context, NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr},
     {ngx_string("opentracing_fastcgi_propagate_context"),
      NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS, propagate_fastcgi_opentracing_context,
      NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr},

--- a/opentracing/src/opentracing_directive.cpp
+++ b/opentracing/src/opentracing_directive.cpp
@@ -154,7 +154,7 @@ char *propagate_opentracing_context(ngx_conf_t *cf, ngx_command_t * /*command*/,
   return static_cast<char *>(NGX_CONF_OK);
 } catch (const std::exception &e) {
   ngx_log_error(NGX_LOG_ERR, cf->log, 0,
-                "opentracing_propatate_context failed: %s", e.what());
+                "opentracing_propagate_context failed: %s", e.what());
   return static_cast<char *>(NGX_CONF_ERROR);
 }
 
@@ -194,7 +194,7 @@ char *propagate_fastcgi_opentracing_context(ngx_conf_t *cf,
   return static_cast<char *>(NGX_CONF_OK);
 } catch (const std::exception &e) {
   ngx_log_error(NGX_LOG_ERR, cf->log, 0,
-                "opentracing_fastcgi_propatate_context failed: %s", e.what());
+                "opentracing_fastcgi_propagate_context failed: %s", e.what());
   return static_cast<char *>(NGX_CONF_ERROR);
 }
 


### PR DESCRIPTION
Allows the `opentracing_propagate_context` to be set at the same level as all other `opentracing_*` directives, allowing you to share configuration across multiple locations.

Mitigates https://github.com/opentracing-contrib/nginx-opentracing/issues/56 somewhat.