### PR TITLE
Add check for missing HTTP block

### DIFF
--- a/opentracing/src/ngx_http_opentracing_module.cpp
+++ b/opentracing/src/ngx_http_opentracing_module.cpp
@@ -77,7 +77,7 @@ static ngx_int_t opentracing_module_init(ngx_conf_t *cf) noexcept {
 static ngx_int_t opentracing_init_worker(ngx_cycle_t *cycle) noexcept try {
   auto main_conf = static_cast<opentracing_main_conf_t *>(
       ngx_http_cycle_get_module_main_conf(cycle, ngx_http_opentracing_module));
-  if (!main_conf->tracer_library.data) {
+  if (!main_conf || !main_conf->tracer_library.data) {
     return NGX_OK;
   }
 


### PR DESCRIPTION
If your nginx config doesn't have a http block (eg it's for a mail server), we get a null pointer crash when initialising the worker.

```
  auto main_conf = static_cast<opentracing_main_conf_t *>(
      ngx_http_cycle_get_module_main_conf(cycle, ngx_http_opentracing_module));
  if (!main_conf->tracer_library.data) {
    return NGX_OK;
  }
```

```
#define ngx_http_cycle_get_module_main_conf(cycle, module)                    \
    (cycle->conf_ctx[ngx_http_module.index] ?                                 \
        ((ngx_http_conf_ctx_t *) cycle->conf_ctx[ngx_http_module.index])      \
            ->main_conf[module.ctx_index]:                                    \
        NULL)
```
