### PR TITLE
Restructure Module Code With Best Practices

### DIFF
--- a/opentracing/src/discover_span_context_keys.cpp
+++ b/opentracing/src/discover_span_context_keys.cpp
@@ -47,7 +47,7 @@ class HeaderKeyWriter : public opentracing::HTTPHeadersWriter {
 // See propagate_opentracing_context, set_tracer.
 //
 // Note: Any keys that a tracer might use for propagation that aren't discovered
-// discovered here will get dropped during propagation.
+// here will get dropped during propagation.
 ngx_array_t* discover_span_context_keys(ngx_pool_t* pool, ngx_log_t* log,
                                         const char* tracing_library,
                                         const char* tracer_config_file) {

--- a/opentracing/src/ngx_http_opentracing_module.cpp
+++ b/opentracing/src/ngx_http_opentracing_module.cpp
@@ -21,12 +21,14 @@ extern "C" {
 extern ngx_module_t ngx_http_opentracing_module;
 }
 
+// clang-format off
 static ngx_int_t opentracing_module_init(ngx_conf_t *cf) noexcept;
 static ngx_int_t opentracing_init_worker(ngx_cycle_t *cycle) noexcept;
 static void opentracing_exit_worker(ngx_cycle_t *cycle) noexcept;
 static void *create_opentracing_main_conf(ngx_conf_t *conf) noexcept;
 static void *create_opentracing_loc_conf(ngx_conf_t *conf) noexcept;
 static char *merge_opentracing_loc_conf(ngx_conf_t *, void *parent, void *child) noexcept;
+// clang-format on
 
 using namespace ngx_opentracing;
 
@@ -44,6 +46,7 @@ const std::pair<ngx_str_t, ngx_str_t> default_opentracing_tags[] = {
     {ngx_string("http.url"), ngx_string("$scheme://$http_host$request_uri")},
     {ngx_string("http.host"), ngx_string("$http_host")}};
 
+// clang-format off
 //------------------------------------------------------------------------------
 // opentracing_commands
 //------------------------------------------------------------------------------
@@ -153,6 +156,7 @@ ngx_module_t ngx_http_opentracing_module = {
     nullptr,                 /* exit master */
     NGX_MODULE_V1_PADDING
 };
+// clang-format on
 
 //------------------------------------------------------------------------------
 // opentracing_module_init


### PR DESCRIPTION
Restructure NGINX module linkage code to be similar to NGINX standards and best practices. This makes the code easier to understand. Remove typo.