### PR TITLE
Fix trivial ubuntu example

### DIFF
--- a/example/trivial/ubuntu-x86_64/Dockerfile-nginx
+++ b/example/trivial/ubuntu-x86_64/Dockerfile-nginx
@@ -13,7 +13,7 @@ RUN set -x \
   && wget -O - http://nginx.org/keys/nginx_signing.key | apt-key add -  \
   && apt-add-repository "deb http://nginx.org/packages/ubuntu/ bionic nginx" \
   && apt-get update \
-  && apt-get install nginx \
+  && apt-get install nginx=1.14.0-1~bionic \
 # Install nginx-opentracing into NGINX's module directory
   && cd /usr/lib/nginx/modules \
   && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.4.0/linux-amd64-nginx-1.14.0-ngx_http_module.so.tgz \


### PR DESCRIPTION
## Motivation
nginx couldn't be started because `1.14.1` was installed

```
nginx: [emerg] module "/etc/nginx/modules/ngx_http_opentracing_module.so" version 1014000 instead of 1014001 in /etc/nginx/nginx.conf:1
```

## Proposed changes
*  pin nginx version to `1.14.0`