### PR TITLE
[ci] add nginx versions 1.15.1 and 1.13.6 to the list of versions to build

### DIFF
--- a/ci/build_module_binaries.sh
+++ b/ci/build_module_binaries.sh
@@ -3,7 +3,7 @@
 set -e
 
 export OPENTRACING_VERSION=1.5.1
-NGINX_VERSIONS=(1.15.0 1.14.0 1.13.12 1.12.2)
+NGINX_VERSIONS=(1.15.1 1.15.0 1.14.0 1.13.12 1.13.6 1.12.2)
 
 # Compile for a portable cpu architecture
 export CFLAGS="-march=x86-64 -fPIC"


### PR DESCRIPTION
In a quest to increase the the range of pre-compiled binaries built via CI. 

I confirmed the versions translate to actually nginx releases define to [here](https://github.com/opentracing-contrib/nginx-opentracing/blob/master/ci/build_module_binary.sh#L7). 

[1.15.1](https://github.com/nginx/nginx/archive/release-1.15.1.tar.gz)
[1.13.6](https://github.com/nginx/nginx/archive/release-1.13.6.tar.gz)

Feedback welcome on PR or context provided. Thanks. 

