### PR TITLE
Add nginx-1.15.8 to binaries list.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
             pyenv global 3.5.2
             python3 --version
             pip3.5 --version
-            pip3.5 install setuptools
+            pip3.5 install --upgrade setuptools
             pip3.5 install docker
             pip3.5 install docker-compose
             pip3.5 install protobuf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
             pyenv global 3.5.2
             python3 --version
             pip3.5 --version
+            pip3.5 install --upgrade pip
             pip3.5 install --upgrade setuptools
             pip3.5 install docker
             pip3.5 install docker-compose

--- a/ci/build_module_binaries.sh
+++ b/ci/build_module_binaries.sh
@@ -3,7 +3,7 @@
 set -e
 
 export OPENTRACING_VERSION=1.5.1
-NGINX_VERSIONS=(1.16.0 1.15.1 1.15.0 1.14.0 1.13.12 1.13.6 1.12.2)
+NGINX_VERSIONS=(1.16.0 1.15.8 1.15.1 1.15.0 1.14.0 1.13.12 1.13.6 1.12.2)
 
 # Compile for a portable cpu architecture
 export CFLAGS="-march=x86-64 -fPIC"


### PR DESCRIPTION
[OpenResty's latest release](https://openresty.org/en/ann-1015008001.html) is based on `nginx-1.15.8`, so this is hopefully useful to others, too.

Resolves #100