### PR TITLE
Add upstream address and name tags

### DIFF
--- a/opentracing/src/ngx_http_opentracing_module.cpp
+++ b/opentracing/src/ngx_http_opentracing_module.cpp
@@ -50,6 +50,7 @@ const std::pair<ngx_str_t, ngx_str_t> default_opentracing_tags[] = {
     {ngx_string("component"), ngx_string("nginx")},
     {ngx_string("nginx.worker_pid"), ngx_string("$pid")},
     {ngx_string("peer.address"), ngx_string("$remote_addr:$remote_port")},
+    {ngx_string("upstream.address"), ngx_string("$upstream_addr")},
     {ngx_string("http.method"), ngx_string("$request_method")},
     {ngx_string("http.url"), ngx_string("$scheme://$http_host$request_uri")},
     {ngx_string("http.host"), ngx_string("$http_host")}};


### PR DESCRIPTION
When a request is redirected to an upstream, then it is not visible
where it went. The ngx_http_upstream module maintains a variable
"upstream_addr" for the resolved IP address + port information. It
also sets the name of the used upstream config entry to the request
as request->upstream->upstream->host.
So add that information to the new tags "upstream.address" and
"upstream.name".