### PR TITLE
Small fixups for datadog tracing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ZIPKIN_CPP_VERSION=v0.5.2
 ARG LIGHTSTEP_VERSION=v0.8.1
 ARG JAEGER_CPP_VERSION=v0.4.2
 ARG GRPC_VERSION=v1.22.x
-ARG DATADOG_VERSION=v0.3.0
+ARG DATADOG_VERSION=v1.1.2
 
 COPY . /src
 
@@ -40,6 +40,8 @@ RUN set -x \
               autoconf \
               libtool \
               g++-7 \
+ && true
+RUN true \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 # (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
 	&& apt-mark showmanual | xargs apt-mark auto > /dev/null \

--- a/opentracing/src/discover_span_context_keys.cpp
+++ b/opentracing/src/discover_span_context_keys.cpp
@@ -59,10 +59,10 @@ ngx_array_t* discover_span_context_keys(ngx_pool_t* pool, ngx_log_t* log,
     return nullptr;
   }
   auto span = tracer->StartSpan("dummySpan");
+  span->SetTag(opentracing::ext::sampling_priority, 0);
   std::vector<opentracing::string_view> keys;
   HeaderKeyWriter carrier_writer{pool, keys};
   auto was_successful = tracer->Inject(span->context(), carrier_writer);
-  span->SetTag(opentracing::ext::sampling_priority, 0);
   if (!was_successful) {
     ngx_log_error(NGX_LOG_ERR, log, 0,
                   "failed to discover span context tags: %s",


### PR DESCRIPTION
The change to `discover_span_context_keys.cpp` is to make sure the sampling priority is set before the context gets injected. The datadog tracer emits an error if sampling priority is changed after a span context has been injected.

Also bumping the version shipped in the docker image. Will try to be more proactive on bumping that in your project in the future.
Some recent users have been using the `opentracing/nginx-opentracing` container as a convenient, minimal sandbox, and these problems got reported.