### PR TITLE
Add version 1.17.8

### DIFF
--- a/ci/build_module_binaries.sh
+++ b/ci/build_module_binaries.sh
@@ -3,7 +3,7 @@
 set -e
 
 export OPENTRACING_VERSION=1.5.1
-NGINX_VERSIONS=(1.17.3 1.17.2 1.17.1 1.17.0 1.16.1 1.16.0 1.15.8 1.15.1 1.15.0 1.14.2 1.13.6)
+NGINX_VERSIONS=(1.17.8 1.17.3 1.17.2 1.17.1 1.17.0 1.16.1 1.16.0 1.15.8 1.15.1 1.15.0 1.14.2 1.13.6)
 
 # Compile for a portable cpu architecture
 export CFLAGS="-march=x86-64 -fPIC"


### PR DESCRIPTION
Hi,

OpenResty [upgraded to `nginx` core 1.17.8 on July 4, 2020](https://openresty.org/en/changelog-1017008.html#version-11781---4-july-2020). I'm hoping this minor change will produce a compatible `nginx-opentracing` binary.