### PR TITLE
Support Opentracing v1.6.0 and Jaeger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,9 @@ ARG NGINX_LABEL=latest
 
 FROM nginx:${NGINX_LABEL}
 
-ARG OPENTRACING_CPP_VERSION=v1.5.1
-ARG ZIPKIN_CPP_VERSION=v0.5.2
-ARG LIGHTSTEP_VERSION=v0.8.1
-ARG JAEGER_CPP_VERSION=v0.4.2
+ARG OPENTRACING_CPP_VERSION=v1.6.0
+ARG JAEGER_CPP_VERSION=v0.6.0
 ARG GRPC_VERSION=v1.22.x
-ARG DATADOG_VERSION=v1.1.2
 
 COPY . /src
 
@@ -41,7 +38,8 @@ RUN set -x \
               libtool \
               g++-7 \
  && true
-RUN true \
+
+ RUN true \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 # (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
 	&& apt-mark showmanual | xargs apt-mark auto > /dev/null \
@@ -49,69 +47,39 @@ RUN true \
 	\
   && cd "$tempDir" \
 ### Use g++ 7
-  # && update-alternatives --remove-all cc \
-  # && update-alternatives --remove-all g++ \
-  # && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.3 10
-  # && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.3 10
-  # && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 \
-  # && update-alternatives --set cc /usr/bin/gcc
-  # && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 \
-  # && 
   && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 5 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 5 \
+### Build gRPC
+  && git clone --depth 1 -b $GRPC_VERSION https://github.com/grpc/grpc \
+  && cd grpc \
+  && git submodule update --depth 1 --init \
+  && make HAS_SYSTEM_PROTOBUF=false \
+  && make install \
+  && cd third_party/protobuf \
+  && make install \
+  && cd "$tempDir" \
 ### Build opentracing-cpp
-  && git clone -b $OPENTRACING_CPP_VERSION https://github.com/opentracing/opentracing-cpp.git \
+  && git clone --depth 1 -b $OPENTRACING_CPP_VERSION https://github.com/opentracing/opentracing-cpp.git \
   && cd opentracing-cpp \
   && mkdir .build && cd .build \
   && cmake -DCMAKE_BUILD_TYPE=Release \
            -DBUILD_TESTING=OFF .. \
   && make && make install \
   && cd "$tempDir" \
-### Build zipkin-cpp-opentracing
-  && apt-get --no-install-recommends --no-install-suggests -y install libcurl4-gnutls-dev \
-  && git clone -b $ZIPKIN_CPP_VERSION https://github.com/rnburn/zipkin-cpp-opentracing.git \
-  && cd zipkin-cpp-opentracing \
-  && mkdir .build && cd .build \
-  && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
-  && make && make install \
-  && cd "$tempDir" \
-  && ln -s /usr/local/lib/libzipkin_opentracing.so /usr/local/lib/libzipkin_opentracing_plugin.so \
 ### Build Jaeger cpp-client
-  && git clone -b $JAEGER_CPP_VERSION https://github.com/jaegertracing/cpp-client.git jaeger-cpp-client \
+  && git clone --depth 1 -b $JAEGER_CPP_VERSION https://github.com/jaegertracing/cpp-client.git jaeger-cpp-client \
   && cd jaeger-cpp-client \
-  && mkdir .build && cd .build \
+  && mkdir .build \
+  && cd .build \
   && cmake -DCMAKE_BUILD_TYPE=Release \
            -DBUILD_TESTING=OFF \
            -DJAEGERTRACING_WITH_YAML_CPP=ON .. \
-  && make && make install \
+  && make \
+  && make install \
   && export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
+  && cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/ \
   && cd "$tempDir" \
   && ln -s /usr/local/lib/libjaegertracing.so /usr/local/lib/libjaegertracing_plugin.so \
-### Build dd-opentracing-cpp
-  && git clone -b $DATADOG_VERSION https://github.com/DataDog/dd-opentracing-cpp.git \
-  && cd dd-opentracing-cpp \
-  && scripts/install_dependencies.sh not-opentracing not-curl not-zlib \
-  && mkdir .build && cd .build \
-  && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
-  && make && make install \
-  && cd "$tempDir" \
-  && ln -s /usr/local/lib/libdd_opentracing.so /usr/local/lib/libdd_opentracing_plugin.so \
-### Build gRPC
-  && git clone -b $GRPC_VERSION https://github.com/grpc/grpc \
-  && cd grpc \
-  && git submodule update --init \
-  && make HAS_SYSTEM_PROTOBUF=false && make install \
-  && cd third_party/protobuf \
-  && make install \
-  && cd "$tempDir" \
-### Build lightstep-tracer-cpp
-  && git clone -b $LIGHTSTEP_VERSION https://github.com/lightstep/lightstep-tracer-cpp.git \
-  && cd lightstep-tracer-cpp \
-  && mkdir .build && cd .build \
-  && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
-  && make && make install \
-  && cd "$tempDir" \
-  && ln -s /usr/local/lib/liblightstep_tracer.so /usr/local/lib/liblightstep_tracer_plugin.so \
 ### Build nginx-opentracing modules
   && NGINX_VERSION=`nginx -v 2>&1` && NGINX_VERSION=${NGINX_VERSION#*nginx/} \
   && echo "deb-src http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list \

--- a/Dockerfile-openresty
+++ b/Dockerfile-openresty
@@ -2,15 +2,15 @@
 # https://github.com/openresty/docker-openresty
 
 ARG RESTY_IMAGE_BASE="ubuntu"
-ARG RESTY_IMAGE_TAG="xenial"
+ARG RESTY_IMAGE_TAG="20.04"
 
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 
 # Docker Build Arguments
-ARG RESTY_VERSION="1.13.6.2"
+ARG RESTY_VERSION="1.19.3.1"
 ARG RESTY_LUAROCKS_VERSION="2.4.4"
-ARG RESTY_OPENSSL_VERSION="1.1.0h"
-ARG RESTY_PCRE_VERSION="8.42"
+ARG RESTY_OPENSSL_VERSION="1.1.1i"
+ARG RESTY_PCRE_VERSION="8.44"
 ARG RESTY_J="1"
 ARG RESTY_CONFIG_OPTIONS="\
     --with-file-aio \
@@ -44,11 +44,8 @@ ARG RESTY_CONFIG_OPTIONS="\
     --add-dynamic-module=/src/opentracing \
     "
 ARG RESTY_CONFIG_OPTIONS_MORE=""
-ARG OPENTRACING_CPP_VERSION="v1.5.1"
-ARG LUA_BRIDGE_TRACER_VERSION="937059912311da3b4f45f46cd7d9a2942a248b2d"
-ARG JAEGER_VERSION="v0.4.2"
-ARG LIGHTSTEP_VERSION="v0.10.1"
-ARG ZIPKIN_VERSION="v0.5.2"
+ARG OPENTRACING_CPP_VERSION="v1.6.0"
+ARG JAEGER_VERSION="0.6.0"
 
 LABEL resty_version="${RESTY_VERSION}"
 LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
@@ -100,21 +97,28 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
   && make && make install \
   && cd /tmp \
   && rm -rf opentracing-cpp \
-### Build bridge tracer
-  && cd /tmp \
-  && git clone https://github.com/opentracing/lua-bridge-tracer.git \
-  && cd lua-bridge-tracer \
-  && git checkout ${LUA_BRIDGE_TRACER_VERSION} \
-  && mkdir .build && cd .build \
-  && cmake -DCMAKE_BUILD_TYPE=Release \
-            .. \
-  && make && make install \
-  && cd /tmp \
-  && rm -rf lua-bridge-tracer \
 ### Install tracers
-  && wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
-  && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/${LIGHTSTEP_VERSION}/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so \
-  && wget -O - https://github.com/rnburn/zipkin-cpp-opentracing/releases/download/${ZIPKIN_VERSION}/linux-amd64-libzipkin_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libzipkin_opentracing_plugin.so \
+  #&& wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
+  && cd /tmp \
+  && wget https://github.com/jaegertracing/jaeger-client-cpp/archive/v${JAEGER_VERSION}.tar.gz \
+  && tar xzf v${JAEGER_VERSION}.tar.gz \
+  && cd jaeger-client-cpp-${JAEGER_VERSION} \
+  && ls -la \
+  && mkdir .build \
+  && cd .build \
+  && cmake -DCMAKE_BUILD_TYPE=Release \
+           -DBUILD_TESTING=OFF \
+           -DJAEGERTRACING_WITH_YAML_CPP=ON .. \
+  && make \
+  && make install \
+  && export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
+  && cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/ \
+  && ln -s /usr/local/lib/libjaegertracing.so /usr/local/lib/libjaegertracing_plugin.so \
+  && cd /tmp \
+  && rm -rf jaeger-client-cpp-${JAEGER_VERSION} v${JAEGER_VERSION}.tar.gz /root/.hunter \
+  && true
+
+RUN true \
 ### Copied from https://github.com/openresty/docker-openresty/blob/master/xenial/Dockerfile
     && cd /tmp \
     && curl -fSL https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ http {
   # Load a vendor tracer
   opentracing_load_tracer /usr/local/lib/libjaegertracing_plugin.so /etc/jaeger-nginx-config.json;
 
-  # or 
+  # or
   #   opentracing_load_tracer /usr/local/lib/liblightstep_tracer_plugin.so /path/to/config;
-  # or 
+  # or
   #   opentracing_load_tracer /usr/local/lib/libzipkin_opentracing_plugin.so /path/to/config;
   # or
   #   opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /path/to/config;
@@ -102,7 +102,7 @@ directives.
 Docker
 ------
 A docker image `opentracing/nginx-opentracing` is provided to support using nginx with OpenTracing
-in a manner analogous to the [nginx Docker image](https://hub.docker.com/_/nginx/). 
+in a manner analogous to the [nginx Docker image](https://hub.docker.com/_/nginx/).
 See [here](example/) for examples of how to use it.
 
 Additionally, custom images can be built by running
@@ -113,7 +113,7 @@ docker build \
        .
 ```
 
-and arguments to weak the versions used can be provided with
+and arguments to tweak the versions used can be provided with
 
 ```bash
 docker build \
@@ -134,6 +134,7 @@ Other build arguments
 
 Building From Source
 --------------------
+
 ```
 $ tar zxvf nginx-1.9.x.tar.gz
 $ cd nginx-1.9.x
@@ -141,11 +142,16 @@ $ ./configure --add-dynamic-module=/absolute/path/to/nginx-opentracing/opentraci
 $ make && sudo make install
 ```
 
-You will also need to install a C++ tracer for either [Jaeger](https://github.com/jaegertracing/jaeger-client-cpp), [LightStep](
-https://github.com/lightstep/lightstep-tracer-cpp), [Datadog](https://github.com/DataDog/dd-opentracing-cpp), or [Zipkin](https://github.com/rnburn/zipkin-cpp-opentracing). For linux x86-64, portable binary plugins are available:
+You will also need to install a C++ tracer for either
+[Jaeger](https://github.com/jaegertracing/jaeger-client-cpp),
+[LightStep](https://github.com/lightstep/lightstep-tracer-cpp),
+[Datadog](https://github.com/DataDog/dd-opentracing-cpp),
+or [Zipkin](https://github.com/rnburn/zipkin-cpp-opentracing).
+For linux x86-64, portable binary plugins are available:
+
 ```
 # Jaeger
-wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v0.4.2/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so
+wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v0.6.0/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so
 
 # LightStep
 wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.8.1/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so

--- a/ci/build_module_binaries.sh
+++ b/ci/build_module_binaries.sh
@@ -3,6 +3,7 @@
 set -e
 
 export OPENTRACING_VERSION=1.5.1
+# export OPENTRACING_VERSION=1.6.0
 NGINX_VERSIONS=(1.19.7 1.19.6 1.19.5 1.19.4 1.19.3 1.19.2 1.18.0 1.17.8 1.17.3 1.17.2 1.17.1 1.17.0 1.16.1 1.16.0 1.15.8 1.15.1 1.15.0 1.14.2 1.13.6)
 
 # Compile for a portable cpu architecture

--- a/ci/install_opentracing.sh
+++ b/ci/install_opentracing.sh
@@ -3,6 +3,7 @@
 set -e
 
 [ -z "${OPENTRACING_VERSION}" ] && export OPENTRACING_VERSION="v1.5.1"
+# [ -z "${OPENTRACING_VERSION}" ] && export OPENTRACING_VERSION="v1.6.0"
 
 # Build OpenTracing
 cd /


### PR DESCRIPTION
Upgrade Opentracing lib to support latest version of Jaeger.
Because other tracer do not support latest Opentracing - removed them.