### PR TITLE
Add new nginx 1.19.x versions

### DIFF
--- a/ci/build_module_binaries.sh
+++ b/ci/build_module_binaries.sh
@@ -3,7 +3,7 @@
 set -e
 
 export OPENTRACING_VERSION=1.5.1
-NGINX_VERSIONS=(1.19.2 1.18.0 1.17.8 1.17.3 1.17.2 1.17.1 1.17.0 1.16.1 1.16.0 1.15.8 1.15.1 1.15.0 1.14.2 1.13.6)
+NGINX_VERSIONS=(1.19.6 1.19.5 1.19.4 1.19.3 1.19.2 1.18.0 1.17.8 1.17.3 1.17.2 1.17.1 1.17.0 1.16.1 1.16.0 1.15.8 1.15.1 1.15.0 1.14.2 1.13.6)
 
 # Compile for a portable cpu architecture
 export CFLAGS="-march=x86-64 -fPIC"


### PR DESCRIPTION
For compatibility with latest security fixes in Nginx releases, new builds of this module are desperately needed.