### PR TITLE
Run system tests against nginx 1.19.7

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,11 +1,11 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG OPENTRACING_CPP_VERSION=v1.5.1
-ARG NGINX_VERSION=1.13.12
+ARG NGINX_VERSION=1.19.7
 
 RUN set -x \
   && apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y \
+  && DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends --no-install-suggests -y \
               build-essential \
               gettext \
               cmake \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: docker.build
+docker.build: test
+	docker build -f Dockerfile -t opentracing-contrib/nginx-opentracing .
+
 .PHONY: test
 test:
 	./ci/system_testing.sh


### PR DESCRIPTION
Problem:

```
After this operation, 7848 kB of additional disk space will be used.
Ign:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 libssl-dev amd64 1.1.1-1ubuntu2.1~18.04.7
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libssl-dev amd64 1.1.1-1ubuntu2.1~18.04.7
  404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1-1ubuntu2.1~18.04.7_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get install -y libssl-dev' returned a non-zero code: 100
```

Update Linux in test environment.
and make sure it works for latest nginx version.