### PR TITLE
Support latest Zipkin tracer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ ARG NGINX_LABEL=latest
 FROM nginx:${NGINX_LABEL}
 
 ARG OPENTRACING_CPP_VERSION=v1.6.0
+ARG ZIPKIN_CPP_VERSION=master
 ARG JAEGER_CPP_VERSION=v0.7.0
 ARG GRPC_VERSION=v1.27.x
-ARG DATADOG_VERSION="master"
+ARG DATADOG_VERSION=master
 
 COPY . /src
 
@@ -63,6 +64,15 @@ RUN set -x \
            -DBUILD_TESTING=OFF .. \
   && make && make install \
   && cd "$tempDir" \
+### Build zipkin-cpp-opentracing
+  && apt-get --no-install-recommends --no-install-suggests -y install libcurl4-gnutls-dev \
+  && git clone --depth 1 -b $ZIPKIN_CPP_VERSION https://github.com/rnburn/zipkin-cpp-opentracing.git \
+  && cd zipkin-cpp-opentracing \
+  && mkdir .build && cd .build \
+  && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
+  && make && make install \
+  && cd "$tempDir" \
+  && ln -s /usr/local/lib/libzipkin_opentracing.so /usr/local/lib/libzipkin_opentracing_plugin.so \
 ### Build Jaeger cpp-client
   && git clone --depth 1 -b $JAEGER_CPP_VERSION https://github.com/jaegertracing/cpp-client.git jaeger-cpp-client \
   && cd jaeger-cpp-client \

--- a/example/go/otel/README.md
+++ b/example/go/otel/README.md
@@ -23,7 +23,8 @@ $ docker-compose up --build
 Send requests to the app:
 
 ```shell
-$ curl localhost:8081
+$ curl localhost:8081  # W3C format traces
+$ curl localhost:8082  # Zipkin format traces
 ```
 
 Visit http://localhost:16686 to view the traces in Jaeger.

--- a/example/go/otel/docker-compose.yaml
+++ b/example/go/otel/docker-compose.yaml
@@ -14,9 +14,11 @@ services:
       # - "6831/udp" # Default endpoint for Jaeger thrift_compact receiver
       - "14268"    # Jaeger http thrift receiver
       - "55680"    # Default endpoint for OpenTelemetry receiver
+      - "9411"     # Zipkin port
       - "8888"     # Metrics
     ports:
       - "55680:55680"
+      - "9411:9411"
       # - "6831:6831/udp"
       - "8888:8888"
       - "14268:14268"
@@ -33,24 +35,27 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
       - ./jaeger-config.json:/etc/jaeger-config.json
+      - ./zipkin-config.json:/etc/zipkin-config.json
     expose:
       - "8081"
+      - "8082"
     ports:
       - "8081:8081"
+      - "8082:8082"
 
   jaeger:
     image: jaegertracing/all-in-one
+    environment:
+      - COLLECTOR_ZIPKIN_HTTP_PORT=19411
     pull_policy: always
     networks:
       example:
         aliases:
           - jaeger
     expose:
-      - "9411"
       - "16686"
       - "14250"
     ports:
-      - "9411:9411"
       - "16686:16686"
       - "14250:14250"
 

--- a/example/go/otel/nginx.conf
+++ b/example/go/otel/nginx.conf
@@ -4,19 +4,39 @@ events {}
 
 http {
   opentracing on;
-
   opentracing_load_tracer /usr/local/lib/libjaegertracing_plugin.so /etc/jaeger-config.json;
+  opentracing_tag nginx_global http;
 
   server {
+    opentracing_tag nginx_server server;
+
     root /var/www;
     error_log /var/log/nginx/debug.log debug;
     listen 8081;
     server_name  web.info;
 
     location / {
-        opentracing_trace_locations off;
+        opentracing_tag nginx_location location;
+        opentracing_trace_locations on;
         proxy_pass http://web:8080;
         opentracing_propagate_context;
     }
   }
+
+  # Zipkin example
+  # server {
+  #   opentracing_tag server_nginx_tag server;
+  #   opentracing_load_tracer /usr/local/lib/libzipkin_opentracing_plugin.so /etc/zipkin-config.json;
+
+  #   root /var/www;
+  #   error_log /var/log/nginx/debug.log debug;
+  #   listen 8081;
+  #   server_name  web.info;
+
+  #   location / {
+  #       opentracing_trace_locations off;
+  #       proxy_pass http://web:8080;
+  #       opentracing_propagate_context;
+  #   }
+  # }
 }

--- a/example/go/otel/otel.yml
+++ b/example/go/otel/otel.yml
@@ -9,6 +9,8 @@ receivers:
       thrift_http:
       # 6831/UDP - not used but specified in jaeger-config.json
       thrift_compact:
+  # 9411 - default zipkin port
+  zipkin:
 processors:
   batch:
 exporters:
@@ -20,6 +22,6 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: [otlp, jaeger]
+      receivers: [otlp, jaeger, zipkin]
       processors: [batch]
       exporters: [logging, jaeger]

--- a/example/go/otel/zipkin-config.json
+++ b/example/go/otel/zipkin-config.json
@@ -1,0 +1,6 @@
+{
+  "service_name": "nginx",
+  "collector_host": "otel",
+  "collector_port": 9411,
+  "sample_rate": 1
+}


### PR DESCRIPTION
Zipkin cpp client supports Opentracing CPP v1.6.0 in https://github.com/rnburn/zipkin-cpp-opentracing/pull/48.
Update Dockerfile to build zipkin tracer.
Add nginx config to GO example for zipkin tracer to test integrations.