### PR TITLE
example: install glide with apt

### DIFF
--- a/example/trivial/jaeger/Dockerfile
+++ b/example/trivial/jaeger/Dockerfile
@@ -10,9 +10,9 @@ RUN set -x \
               ca-certificates \
               git \
               curl \
+              golang-glide \
   && export PATH=$PATH:$GOPATH/bin \
   && mkdir -p $GOPATH/bin \
-  && curl https://glide.sh/get | sh \
   && cd go/src/hello-backend \
   && glide up \
   && glide install \

--- a/example/trivial/ubuntu-x86_64/Dockerfile
+++ b/example/trivial/ubuntu-x86_64/Dockerfile
@@ -10,9 +10,9 @@ RUN set -x \
               ca-certificates \
               git \
               curl \
+              golang-glide \
   && export PATH=$PATH:$GOPATH/bin \
   && mkdir -p $GOPATH/bin \
-  && curl https://glide.sh/get | sh \
   && cd go/src/hello-backend \
   && glide up \
   && glide install \


### PR DESCRIPTION
FIxed build of examples. glide.sh is down