### PR TITLE
fix a copy/paste typo: too many format specifiers

### DIFF
--- a/opentracing/src/load_tracer.cpp
+++ b/opentracing/src/load_tracer.cpp
@@ -21,7 +21,7 @@ ngx_int_t load_tracer(ngx_log_t* log, const char* tracer_library,
                     error_message.c_str());
     } else {
       ngx_log_error(NGX_LOG_ERR, log, 0,
-                    "Failed to load tracing library %s: %s", tracer_library);
+                    "Failed to load tracing library %s", tracer_library);
     }
     return NGX_ERROR;
   }


### PR DESCRIPTION
I noticed a typo in the error logging within `load_tracer`.  Here's a fix.