### PR TITLE
QuickFix: Updating example to match Docker image location

### DIFF
--- a/example/go/otel/docker-compose.yaml
+++ b/example/go/otel/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - "14268:14268"
 
   nginx:
-    image: opentracing-contrib/nginx-opentracing
+    image: opentracing/nginx-opentracing
     restart: on-failure
     depends_on:
       - otel


### PR DESCRIPTION
The docker image with nginx and opentracing has moved:
- https://hub.docker.com/r/opentracing/nginx-opentracing