### PR TITLE
Convert Dockerfile to multi-stage build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,14 @@ jobs:
       - run: ./ci/install_opentracing.sh
       - run: ./ci/do_ci.sh build
   docker_image:
-    machine: true
+    machine:
+      image: ubuntu-2004:202107-02
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - run:
-          command: docker build -t opentracing/nginx-opentracing .
+          command: docker build -t opentracing/nginx-opentracing --target final .
   openresty_docker_image:
     machine: true
     steps:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,132 +1,135 @@
-ARG NGINX_LABEL=latest
+# syntax=docker/dockerfile:1.3
+FROM nginx:1.21.1 as build-base
 
-FROM nginx:${NGINX_LABEL}
+RUN apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+    autoconf \
+    autogen \
+    automake \
+    build-essential \
+    ca-certificates \
+    cmake \
+    g++-7 \
+    git \
+    golang \
+    libcurl4-openssl-dev \
+    libprotobuf-dev \
+    libtool \
+    libz-dev \
+    pkg-config \
+    protobuf-compiler \
+    wget
 
-ARG OPENTRACING_CPP_VERSION=v1.6.0
-ARG ZIPKIN_CPP_VERSION=master
-ARG JAEGER_CPP_VERSION=v0.7.0
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 5 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 5
+
+
+### Build gRPC
+FROM build-base as grpc
 ARG GRPC_VERSION=v1.27.x
+
+RUN git clone --depth 1 -b $GRPC_VERSION https://github.com/grpc/grpc \
+    && cd grpc \
+    && git submodule update --depth 1 --init \
+    && make HAS_SYSTEM_PROTOBUF=false \
+    && make install \
+    && cd third_party/protobuf \
+    && make install
+
+
+### Build opentracing-cpp
+FROM build-base as opentracing-cpp
+ARG OPENTRACING_CPP_VERSION=v1.6.0
+
+RUN git clone --depth 1 -b $OPENTRACING_CPP_VERSION https://github.com/opentracing/opentracing-cpp.git \
+    && cd opentracing-cpp \
+    && mkdir .build && cd .build \
+    && cmake -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF .. \
+    && make && make install
+
+
+### Build zipkin-cpp-opentracing
+FROM opentracing-cpp as zipkin-cpp-opentracing
+ARG ZIPKIN_CPP_VERSION=master
+
+RUN apt-get --no-install-recommends --no-install-suggests -y install libcurl4-gnutls-dev
+
+RUN git clone --depth 1 -b $ZIPKIN_CPP_VERSION https://github.com/rnburn/zipkin-cpp-opentracing.git \
+    && cd zipkin-cpp-opentracing \
+    && mkdir .build && cd .build \
+    && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
+    && make && make install \
+    && ln -s /usr/local/lib/libzipkin_opentracing.so /usr/local/lib/libzipkin_opentracing_plugin.so
+
+
+### Build Jaeger cpp-client
+FROM build-base as jaeger-cpp-client
+ARG JAEGER_CPP_VERSION=v0.7.0
+
+RUN git clone --depth 1 -b $JAEGER_CPP_VERSION https://github.com/jaegertracing/jaeger-client-cpp \
+    && cd jaeger-client-cpp \
+    && mkdir .build \
+    && cd .build \
+    && cmake -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF \
+    -DJAEGERTRACING_WITH_YAML_CPP=ON .. \
+    && make \
+    && make install \
+    && export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
+    && cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/ \
+    && mkdir /hunter \
+    && cp -r $HUNTER_INSTALL_DIR/lib /hunter/ \
+    && cp -r $HUNTER_INSTALL_DIR/include /hunter/ \
+    && ln -s /usr/local/lib/libjaegertracing.so /usr/local/lib/libjaegertracing_plugin.so
+
+
+### Build dd-opentracing-cpp
+FROM opentracing-cpp as dd-opentracing-cpp
 ARG DATADOG_VERSION=master
+
+RUN git clone --depth 1 -b $DATADOG_VERSION https://github.com/DataDog/dd-opentracing-cpp.git \
+    && cd dd-opentracing-cpp \
+    && scripts/install_dependencies.sh not-opentracing not-curl not-zlib \
+    && mkdir .build && cd .build \
+    && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
+    && make && make install \
+    && ln -s /usr/local/lib/libdd_opentracing.so /usr/local/lib/libdd_opentracing_plugin.so
+
+
+### Build nginx-opentracing modules
+FROM build-base as build-nginx
+
+COPY --from=jaeger-cpp-client /hunter /hunter
 
 COPY . /src
 
-RUN set -x \
-# install nginx-opentracing package dependencies
-  && apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y \
-              libcurl4-openssl-dev \
-              libprotobuf-dev \
-              protobuf-compiler \
-# save list of currently-installed packages so build dependencies can be cleanly removed later
-	&& savedAptMark="$(apt-mark showmanual)" \
-# new directory for storing sources and .deb files
-	&& tempDir="$(mktemp -d)" \
-	&& chmod 777 "$tempDir" \
-			\
-# (777 to ensure APT's "_apt" user can access it too)
-## Build OpenTracing package and tracers
-  && apt-get install --no-install-recommends --no-install-suggests -y \
-              build-essential \
-              cmake \
-              git \
-              ca-certificates \
-              pkg-config \
-              wget \
-              golang \
-              libz-dev \
-              automake \
-              autogen \
-              autoconf \
-              libtool \
-              g++-7 \
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
-	&& apt-mark showmanual | xargs apt-mark auto > /dev/null \
-	&& { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
-  && cd "$tempDir" \
-### Use g++ 7
-  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 5 \
-  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 5 \
-### Build gRPC
-  && git clone --depth 1 -b $GRPC_VERSION https://github.com/grpc/grpc \
-  && cd grpc \
-  && git submodule update --depth 1 --init \
-  && make HAS_SYSTEM_PROTOBUF=false \
-  && make install \
-  && cd third_party/protobuf \
-  && make install \
-  && cd "$tempDir" \
-### Build opentracing-cpp
-  && git clone --depth 1 -b $OPENTRACING_CPP_VERSION https://github.com/opentracing/opentracing-cpp.git \
-  && cd opentracing-cpp \
-  && mkdir .build && cd .build \
-  && cmake -DCMAKE_BUILD_TYPE=Release \
-           -DBUILD_TESTING=OFF .. \
-  && make && make install \
-  && cd "$tempDir" \
-### Build zipkin-cpp-opentracing
-  && apt-get --no-install-recommends --no-install-suggests -y install libcurl4-gnutls-dev \
-  && git clone --depth 1 -b $ZIPKIN_CPP_VERSION https://github.com/rnburn/zipkin-cpp-opentracing.git \
-  && cd zipkin-cpp-opentracing \
-  && mkdir .build && cd .build \
-  && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
-  && make && make install \
-  && cd "$tempDir" \
-  && ln -s /usr/local/lib/libzipkin_opentracing.so /usr/local/lib/libzipkin_opentracing_plugin.so \
-### Build Jaeger cpp-client
-  && git clone --depth 1 -b $JAEGER_CPP_VERSION https://github.com/jaegertracing/cpp-client.git jaeger-cpp-client \
-  && cd jaeger-cpp-client \
-  && mkdir .build \
-  && cd .build \
-  && cmake -DCMAKE_BUILD_TYPE=Release \
-           -DBUILD_TESTING=OFF \
-           -DJAEGERTRACING_WITH_YAML_CPP=ON .. \
-  && make \
-  && make install \
-  && export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
-  && cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/ \
-  && cd "$tempDir" \
-  && ln -s /usr/local/lib/libjaegertracing.so /usr/local/lib/libjaegertracing_plugin.so \
-### Build dd-opentracing-cpp
-  && git clone --depth 1 -b $DATADOG_VERSION https://github.com/DataDog/dd-opentracing-cpp.git \
-  && cd dd-opentracing-cpp \
-  && scripts/install_dependencies.sh not-opentracing not-curl not-zlib \
-  && mkdir .build && cd .build \
-  && cmake -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF .. \
-  && make && make install \
-  && cd "$tempDir" \
-  && ln -s /usr/local/lib/libdd_opentracing.so /usr/local/lib/libdd_opentracing_plugin.so \
-### Build nginx-opentracing modules
-  && NGINX_VERSION=`nginx -v 2>&1` && NGINX_VERSION=${NGINX_VERSION#*nginx/} \
-  && echo "deb-src http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list \
-  && apt-get update \
-  && apt-get build-dep -y nginx \
-  && wget -O nginx-release-${NGINX_VERSION}.tar.gz https://github.com/nginx/nginx/archive/release-${NGINX_VERSION}.tar.gz \
-  && tar zxf nginx-release-${NGINX_VERSION}.tar.gz \
-  && cd nginx-release-${NGINX_VERSION} \
-  && NGINX_MODULES_PATH=$(nginx -V 2>&1 | grep -oP "modules-path=\K[^\s]*") \
-  && auto/configure \
-        --with-compat \
-        --add-dynamic-module=/src/opentracing \
-        --with-cc-opt="-I$HUNTER_INSTALL_DIR/include" \
-        --with-ld-opt="-L$HUNTER_INSTALL_DIR/lib" \
-        --with-debug \
-  && make modules \
-  && cp objs/ngx_http_opentracing_module.so $NGINX_MODULES_PATH/ \
-	# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-  && rm -rf /src \
-  && rm -rf $HOME/.hunter \
-  && if [ -n "$tempDir" ]; then \
-  	apt-get purge -y --auto-remove \
-  	&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
-  fi
+RUN echo "deb-src http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get build-dep -y nginx
 
-# forward request and error logs to docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-	&& ln -sf /dev/stderr /var/log/nginx/error.log
+RUN wget -O nginx-release-${NGINX_VERSION}.tar.gz https://github.com/nginx/nginx/archive/release-${NGINX_VERSION}.tar.gz \
+    && tar zxf nginx-release-${NGINX_VERSION}.tar.gz \
+    && cd nginx-release-${NGINX_VERSION} \
+    && NGINX_MODULES_PATH=$(nginx -V 2>&1 | grep -oP "modules-path=\K[^\s]*") \
+    && auto/configure \
+    --with-compat \
+    --add-dynamic-module=/src/opentracing \
+    --with-cc-opt="-I/hunter/include" \
+    --with-ld-opt="-L/hunter/lib" \
+    --with-debug \
+    && make modules \
+    && cp objs/ngx_http_opentracing_module.so $NGINX_MODULES_PATH/
 
-EXPOSE 80
+
+### Build final image
+FROM nginx:1.21.1 as final
+
+COPY --from=build-nginx /usr/lib/nginx/modules/ /usr/lib/nginx/modules/
+COPY --from=dd-opentracing-cpp /usr/local/lib/ /usr/local/lib/
+COPY --from=jaeger-cpp-client /usr/local/lib/ /usr/local/lib/
+COPY --from=zipkin-cpp-opentracing /usr/local/lib/ /usr/local/lib/
+COPY --from=opentracing-cpp /usr/local/lib/ /usr/local/lib/
+COPY --from=grpc /usr/local/lib/ /usr/local/lib/
 
 STOPSIGNAL SIGTERM
-
-CMD ["nginx", "-g", "daemon off;"]

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -29,13 +29,13 @@ elif [[ "$1" == "push_docker_image" ]]; then
   VERSION_TAG="$(git describe --abbrev=0 --tags)"
   VERSION="${VERSION_TAG/v/}"
   # nginx
-  docker build -t opentracing/nginx-opentracing .
+  docker build -t opentracing/nginx-opentracing --target final .
   docker tag opentracing/nginx-opentracing opentracing/nginx-opentracing:${VERSION}
   docker push opentracing/nginx-opentracing:${VERSION}
   docker tag opentracing/nginx-opentracing opentracing/nginx-opentracing:latest
   docker push opentracing/nginx-opentracing:latest
 
-  NGINX_VERSION="$(docker inspect --format '{{json .Config.Env }}' opentracing/nginx-opentracing | awk -F, '{ sub(/^.*NGINX_VERSION=/, ""); print substr($1, 1, length($1)-1)}')"
+  NGINX_VERSION="$(grep -m1 'FROM nginx:' <Dockerfile | awk -F'[: ]' '{print $3}')"
   docker tag opentracing/nginx-opentracing opentracing/nginx-opentracing:nginx-${NGINX_VERSION}
   docker push opentracing/nginx-opentracing:nginx-${NGINX_VERSION}
 


### PR DESCRIPTION
- Use multi-stage build to improve caching and avoid building if the version hasn't changed for a specific library
- Reduce size of final image
- Added specific version of NGINX that can be updated automatically with dependabot when a new version comes out