### PR TITLE
Update links for shared libraries in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,4 +197,6 @@ COPY --from=opentracing-cpp /usr/local/lib/ /usr/local/lib/
 # gRPC doesn't seem to be used
 # COPY --from=grpc /usr/local/lib/ /usr/local/lib/
 
+RUN ldconfig
+
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
The docker image for latest changes has problem to run with opentracing module.

```shell
$ docker run -it opentracing/nginx-opentracing:edge nginx -g "load_module /usr/lib/nginx/modules/ngx_http_opentracing_module.so;"
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2021/09/14 16:49:01 [emerg] 1#1: dlopen() "/usr/lib/nginx/modules/ngx_http_opentracing_module.so" failed (libopentracing.so.1: cannot open shared object file: No such file or directory) in command line
nginx: [emerg] dlopen() "/usr/lib/nginx/modules/ngx_http_opentracing_module.so" failed (libopentracing.so.1: cannot open shared object file: No such file or directory) in command line
```