### PR TITLE
Add Release drafter and PR labeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,66 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - "enhancement"
+  - title: '💣 Breaking Change'
+    labels:
+      - "change"
+  - title: '🐛 Bug Fixes'
+    labels:
+      - "bug"
+  - title: '📝 Documentation'
+    labels:
+      - "documentation"
+  - title: '🔨 Maintenance'
+    labels:
+      - "chore"
+  - title: '⬆️ Dependencies'
+    labels:
+      - "dependencies"
+version-resolver:
+  major:
+    labels:
+      - 'change'
+  minor:
+    labels:
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'chore'
+      - 'dependencies'
+      - 'documentation'
+  default: patch
+exclude-labels:
+  - 'skip-changelog'
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'chore'
+    branch:
+      - '/chore\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/enh\/.+/'
+      - '/enhancement\/.+/'
+      - '/feat\/.+/'
+      - '/feature\/.+/'
+    title:
+      - '/feat/i'
+  - label: 'dependencies'
+    branch:
+      - '/deps\/.+/'
+template: |
+  ## New in NGINX plugin for OpenTracing v$RESOLVED_VERSION
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add https://github.com/release-drafter/release-drafter to help with releases:
- It will automatically label PRs based on the branch name/keywords in the title/file modified.
- It will draft a new release with all the PRs since the last tag, categorizing them based on the applied label.