### PR TITLE
Update go example to use latest master docker build

### DIFF
--- a/example/go/otel/docker-compose.yaml
+++ b/example/go/otel/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   otel:
-    image: otel/opentelemetry-collector-dev:latest
+    image: otel/opentelemetry-collector:latest
     pull_policy: always
     volumes:
       - ./otel.yml:/conf/otel-collector-config.yml
@@ -24,7 +24,7 @@ services:
       - "14268:14268"
 
   nginx:
-    image: opentracing/nginx-opentracing
+    image: opentracing/nginx-opentracing:edge
     restart: on-failure
     depends_on:
       - otel


### PR DESCRIPTION
Changed the example `docker-compose.yaml` to use
new docker image tag with master changes.
Also use stable version of opentelemetry collector.