### PR TITLE
[Examples] Change default otel collector for go

### DIFF
--- a/example/go/otel/Dockerfile
+++ b/example/go/otel/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN go build -o /app .
 
 FROM scratch AS bin
-ENV OT_COLLECTOR_ADDR="localhost:55680"
+ENV OT_COLLECTOR_ADDR="localhost:4317"
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app /
 ENTRYPOINT ["/app"]

--- a/example/go/otel/docker-compose.yaml
+++ b/example/go/otel/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     expose:
       # - "6831/udp" # Default endpoint for Jaeger thrift_compact receiver
       - "14268"    # Jaeger http thrift receiver
-      - "55680"    # Default endpoint for OpenTelemetry receiver
+      - "4317"     # Default endpoint for OpenTelemetry receiver
       - "9411"     # Zipkin port
       - "8888"     # Metrics
     ports:
@@ -72,7 +72,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      OT_COLLECTOR_ADDR: otel:55680
+      OT_COLLECTOR_ADDR: otel:4317
 
 networks:
   example: {}

--- a/example/go/otel/main.go
+++ b/example/go/otel/main.go
@@ -35,7 +35,7 @@ func main() {
 func run() error {
 	collector_addr := os.Getenv("OT_COLLECTOR_ADDR")
 	if collector_addr == "" {
-		collector_addr = "localhost:55680"
+		collector_addr = "localhost:4317"
 	}
 
 	shutdown, err := initProvider("checkout", collector_addr)


### PR DESCRIPTION
The default port changed for recent version of opentelemetry-collector.

https://github.com/open-telemetry/opentelemetry-collector/blob/5ee979a1bb0d0343e98913cbfb8bff92d43b8378/receiver/otlpreceiver/README.md#L28

```

    endpoint (default = 0.0.0.0:4317 for grpc protocol, 0.0.0.0:4318 http protocol): host:port to which the receiver is going to receive data. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.

```

Closes #217