### PR TITLE
Update OpenResty to 3.19.9.1, fix PRCRE and LuaRocks URLs

### DIFF
--- a/Dockerfile-openresty
+++ b/Dockerfile-openresty
@@ -7,9 +7,9 @@ ARG RESTY_IMAGE_TAG="20.04"
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 
 # Docker Build Arguments
-ARG RESTY_VERSION="1.19.3.1"
-ARG RESTY_LUAROCKS_VERSION="2.4.4"
-ARG RESTY_OPENSSL_VERSION="1.1.1i"
+ARG RESTY_VERSION="1.19.9.1"
+ARG RESTY_LUAROCKS_VERSION="3.7.0"
+ARG RESTY_OPENSSL_VERSION="1.1.1l"
 ARG RESTY_PCRE_VERSION="8.44"
 ARG RESTY_J="1"
 ARG RESTY_CONFIG_OPTIONS="\
@@ -67,63 +67,63 @@ COPY . /src
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        curl \
-        gettext-base \
-        libgd-dev \
-        libgeoip-dev \
-        libncurses5-dev \
-        libperl-dev \
-        libreadline-dev \
-        libxslt1-dev \
-        make \
-        perl \
-        unzip \
-        zlib1g-dev \
-        git \
-        cmake \
-        lua5.1-dev \
-        wget \
-### Build opentracing-cpp
-  && cd /tmp \
-  && git clone --depth 1 -b ${OPENTRACING_CPP_VERSION} https://github.com/opentracing/opentracing-cpp.git \
-  && cd opentracing-cpp \
-  && mkdir .build && cd .build \
-  && cmake -DCMAKE_BUILD_TYPE=Release \
-           -DBUILD_MOCKTRACER=OFF \
-           -DBUILD_STATIC_LIBS=OFF \
-           -DBUILD_TESTING=OFF .. \
-  && make && make install \
-  && cd /tmp \
-  && rm -rf opentracing-cpp \
-### Install tracers
-  #&& wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
-  && cd /tmp \
-  && wget https://github.com/jaegertracing/jaeger-client-cpp/archive/v${JAEGER_VERSION}.tar.gz \
-  && tar xzf v${JAEGER_VERSION}.tar.gz \
-  && cd jaeger-client-cpp-${JAEGER_VERSION} \
-  && ls -la \
-  && mkdir .build \
-  && cd .build \
-  && cmake -DCMAKE_BUILD_TYPE=Release \
-           -DBUILD_TESTING=OFF \
-           -DJAEGERTRACING_WITH_YAML_CPP=ON .. \
-  && make \
-  && make install \
-  && export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
-  && cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/ \
-  && ln -s /usr/local/lib/libjaegertracing.so /usr/local/lib/libjaegertracing_plugin.so \
-  && cd /tmp \
-  && rm -rf jaeger-client-cpp-${JAEGER_VERSION} v${JAEGER_VERSION}.tar.gz /root/.hunter \
-  && true
+    build-essential \
+    ca-certificates \
+    curl \
+    gettext-base \
+    libgd-dev \
+    libgeoip-dev \
+    libncurses5-dev \
+    libperl-dev \
+    libreadline-dev \
+    libxslt1-dev \
+    make \
+    perl \
+    unzip \
+    zlib1g-dev \
+    git \
+    cmake \
+    lua5.1-dev \
+    wget \
+    ### Build opentracing-cpp
+    && cd /tmp \
+    && git clone --depth 1 -b ${OPENTRACING_CPP_VERSION} https://github.com/opentracing/opentracing-cpp.git \
+    && cd opentracing-cpp \
+    && mkdir .build && cd .build \
+    && cmake -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_MOCKTRACER=OFF \
+    -DBUILD_STATIC_LIBS=OFF \
+    -DBUILD_TESTING=OFF .. \
+    && make && make install \
+    && cd /tmp \
+    && rm -rf opentracing-cpp \
+    ### Install tracers
+    #&& wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/v${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
+    && cd /tmp \
+    && wget https://github.com/jaegertracing/jaeger-client-cpp/archive/v${JAEGER_VERSION}.tar.gz \
+    && tar xzf v${JAEGER_VERSION}.tar.gz \
+    && cd jaeger-client-cpp-${JAEGER_VERSION} \
+    && ls -la \
+    && mkdir .build \
+    && cd .build \
+    && cmake -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF \
+    -DJAEGERTRACING_WITH_YAML_CPP=ON .. \
+    && make \
+    && make install \
+    && export HUNTER_INSTALL_DIR=$(cat _3rdParty/Hunter/install-root-dir) \
+    && cp $HUNTER_INSTALL_DIR/lib/libyaml*so /usr/local/lib/ \
+    && ln -s /usr/local/lib/libjaegertracing.so /usr/local/lib/libjaegertracing_plugin.so \
+    && cd /tmp \
+    && rm -rf jaeger-client-cpp-${JAEGER_VERSION} v${JAEGER_VERSION}.tar.gz /root/.hunter \
+    && true
 
 RUN true \
-### Copied from https://github.com/openresty/docker-openresty/blob/master/xenial/Dockerfile
+    ### Copied from https://github.com/openresty/docker-openresty/blob/master/xenial/Dockerfile
     && cd /tmp \
     && curl -fSL https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
-    && curl -fSL https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && curl -fSL https://downloads.sourceforge.net/project/pcre/pcre/${RESTY_PCRE_VERSION}/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
     && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
     && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \
@@ -133,18 +133,18 @@ RUN true \
     && make -j${RESTY_J} install \
     && cd /tmp \
     && rm -rf \
-        openssl-${RESTY_OPENSSL_VERSION} \
-        openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
-        openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
-        pcre-${RESTY_PCRE_VERSION}.tar.gz pcre-${RESTY_PCRE_VERSION} \
-    && curl -fSL https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    openssl-${RESTY_OPENSSL_VERSION} \
+    openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+    openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
+    pcre-${RESTY_PCRE_VERSION}.tar.gz pcre-${RESTY_PCRE_VERSION} \
+    && curl -fSL https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && cd luarocks-${RESTY_LUAROCKS_VERSION} \
     && ./configure \
-        --prefix=/usr/local/openresty/luajit \
-        --with-lua=/usr/local/openresty/luajit \
-        --lua-suffix=jit-2.1.0-beta3 \
-        --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1 \
+    --prefix=/usr/local/openresty/luajit \
+    --with-lua=/usr/local/openresty/luajit \
+    --lua-suffix=jit-2.1.0-beta3 \
+    --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1 \
     && make build \
     && make install \
     && cd /tmp \


### PR DESCRIPTION
- Updated OpenResty, LuaRocks and OpenSSL
- Fixed URLs for PCRE and LuaRocks