### PR TITLE
Cancel previously running jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,10 @@ on:
 env:
   PLATFORMS: "linux/arm,linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
 
+concurrency:
+  group: ${{ github.ref_name }}-docker
+  cancel-in-progress: true
+
 jobs:
     build-docker:
       name: Build Docker Image


### PR DESCRIPTION
This will stop an "old" run of the workflow that is still not completed when there's a new push for the same branch/PR.

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency