### PR TITLE
Clean up build argument list and add note on lightstep tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,8 @@ docker build \
 Other build arguments
 
 * `OPENTRACING_CPP_VERSION`
-* `ZIPKIN_CPP_VERSION`
-* `LIGHTSTEP_VERSION`
 * `JAEGER_CPP_VERSION`
 * `GRPC_VERSION`
-* `NGINX_OPENTRACING_VERSION`
-
 
 Building From Source
 --------------------
@@ -144,7 +140,7 @@ $ make && sudo make install
 
 You will also need to install a C++ tracer for either
 [Jaeger](https://github.com/jaegertracing/jaeger-client-cpp),
-[LightStep](https://github.com/lightstep/lightstep-tracer-cpp),
+[LightStep](https://github.com/lightstep/lightstep-tracer-cpp) ([Available for OpenTracing 1.5.x](https://github.com/lightstep/lightstep-tracer-cpp#building)),
 [Datadog](https://github.com/DataDog/dd-opentracing-cpp),
 or [Zipkin](https://github.com/rnburn/zipkin-cpp-opentracing).
 For linux x86-64, portable binary plugins are available:


### PR DESCRIPTION
The LIGHTSTEP_VERSION and ZIPKIN_CPP_VERSION build arguments were removed in https://github.com/opentracing-contrib/nginx-opentracing/pull/155/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-L7. The NGINX_OPENTRACING_VERSION build argument was removed in https://github.com/opentracing-contrib/nginx-opentracing/pull/37/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10. This pr cleans up the list of build arguments available for use.

Worth noting: it looks like [Zipkin now supports OpenTracing 1.6.0](https://github.com/rnburn/zipkin-cpp-opentracing/blob/master/ci/build_plugin.sh#L12). Maybe we should add the Zipkin tracer back in to the docker image?