### PR TITLE
Update Docker image for gRPC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/test"
     schedule:
       interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/test/environment/grpc"
+    schedule:
+      interval: "daily"

--- a/test/environment/grpc/Dockerfile
+++ b/test/environment/grpc/Dockerfile
@@ -1,3 +1,12 @@
-FROM grpc/python:1.13-onbuild
+FROM python:3.10
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
+
 ENTRYPOINT ["python", "-u"]
 CMD ["app.py"]

--- a/test/environment/grpc/requirements.txt
+++ b/test/environment/grpc/requirements.txt
@@ -1,1 +1,2 @@
-#grpcio-tools
+grpcio-tools==1.47.0
+grpcio==1.47.0


### PR DESCRIPTION
Replaces the deprecated Docker `grpc/python:1.13-onbuild`.