### PR TITLE
Build modules against same GLIBC as for official Nginx image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ docker-image:
 docker-image-alpine:
 	DOCKER_BUILDKIT=1 docker build -f Dockerfile -t opentracing-contrib/nginx-opentracing --target final --build-arg BUILD_OS=alpine .
 
+docker-build-binaries:
+	DOCKER_BUILDKIT=1 docker buildx build --build-arg NGINX_VERSION=1.25.4 --platform linux/amd64 -f build/Dockerfile -t nginx-opentracing-binaries --target=export --output "type=local,dest=out" --progress=plain --no-cache --pull .
+
 .PHONY: test
 test:
 	./ci/system_testing.sh

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10 as base
+FROM debian:stable as base
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
Extracted the problem described in https://github.com/DataDog/dd-opentracing-cpp/pull/276#issuecomment-1954260078

## What we have now?

We build docker images base on official nginx images (debian or alpine): https://github.com/opentracing-contrib/nginx-opentracing/blob/ee6c78630a09bad1dc27ca2c2a6a4acb3e8a3e16/Dockerfile#L244 

In same time we build bin modules for releasing using image ubuntu:2023 [build/Dockerfile](https://github.com/opentracing-contrib/nginx-opentracing/blob/master/build/Dockerfile#L1).

The problem that nginx images most of time would have older GLIBC version.

@dgoffredo wrote:

```
The latest release (v0.34.0) of nginx-opentracing is no longer compatible with nginx's debian-based docker images. nginx-opentracing v0.34.0 requires GLIBC 2.38, while e.g. nginx:1.25.4 has GLIBC 2.36:
```

## Proposals

* Specify the GLIBC version in binaries build to be the same as in nginx
* Build multiple modules built against different OS: debian, ubuntu, alpine

@lucacome What will be your thoughts about this?
