### PR TITLE
Extract nginx version from Dockerfile argument

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Output Variables
         id: var
         run: |
-          echo "nginx_version=$(grep -m1 'FROM nginx:' <Dockerfile | awk -F'[: ]' '{print $3}')" >> $GITHUB_OUTPUT
+          echo "nginx_version=$(grep -m1 'ARG BUILD_NGINX_VERSION=' <Dockerfile | awk -F'[= ]' '{print $3}')" >> $GITHUB_OUTPUT
+
+      - name: Nginx version
+        run: echo "${{ steps.var.outputs.nginx_version }}"
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
In 0.35.0 release the broken tag created for Docker images.
Identified the problem with detecting nginx version.