### PR TITLE
Fix markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ directives.
 
 A docker image `opentracing/nginx-opentracing` is provided to support using nginx with OpenTracing
 in a manner analogous to the [nginx Docker image](https://hub.docker.com/_/nginx/).
-See [here](example/) for examples of how to use it.
+See [examples](example/) of how to use it.
 
 Additionally, custom images can be built by running
 

--- a/doc/Tutorial.md
+++ b/doc/Tutorial.md
@@ -184,4 +184,4 @@ like after having made both of these changes:
 
 ![alt text](data/nginx-upload-trace5.png "Trace")
 
-The full source code can be viewed [here](../example/zoo).
+The full source code can be viewed in the [example](../example/zoo).

--- a/example/trivial/ubuntu-x86_64/README.md
+++ b/example/trivial/ubuntu-x86_64/README.md
@@ -3,7 +3,7 @@
 Demonstates how to set up nginx-opentracing and Jaeger for `linux-x86_64` using
 prebuilt binary images.
 
-NGINX-1.14.0 is installed for Ubuntu following the instructions [here](https://www.nginx.com/resources/wiki/start/topics/tutorials/install/#official-debian-ubuntu-packages).
+NGINX-1.14.0 is installed for Ubuntu following the [instructions](https://www.nginx.com/resources/wiki/start/topics/tutorials/install/#official-debian-ubuntu-packages).
 
 nginx-opentracing is installed into NGINX's module directory with
 


### PR DESCRIPTION
Fixes errors about markdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved link clarity in the Docker section of the README by replacing generic “here” with descriptive “examples”; link destination unchanged.
  * Updated Tutorial text to explicitly reference the example source path, enhancing readability without altering navigation.
  * Refined Ubuntu installation note in the example by replacing a vague “here” link with a clearly labeled “instructions” link; target unchanged.
  * Overall: clearer wording and more descriptive links for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->