### PR TITLE
Build arm64 modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,12 +99,12 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: nginx-opentracing-modules-${{ matrix.nginx_version }}
-          path: linux-*-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.*
+          name: nginx-opentracing-modules-${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }}
+          path: linux-${{ steps.arch.outputs.arch }}-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.*
 
       - name: Upload binaries on release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.ref_type == 'tag'
         run: |
-          gh release upload ${{ github.ref_name }} linux-*-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.* --clobber
+          gh release upload ${{ github.ref_name }} linux-${{ steps.arch.outputs.arch }}-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.* --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,12 @@ jobs:
 
   build-binaries:
     name: Build Binaries
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     needs: release-notes
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
         nginx_version:
           [
             1.21.6,
@@ -68,6 +69,11 @@ jobs:
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Get architecture
+        id: arch
+        run: |
+          if [ "$(uname -m)" = "x86_64" ]; then echo "arch=amd64" >> $GITHUB_OUTPUT; else echo "arch=arm64" >> "$GITHUB_OUTPUT"; fi
+
       - name: Build binary
         uses: docker/build-push-action@v7
         with:
@@ -75,9 +81,9 @@ jobs:
           push: false
           file: build/Dockerfile
           tags: ${{ matrix.nginx_version }}
-          cache-from: type=gha,scope=${{ matrix.nginx_version }}
-          cache-to: type=gha,scope=${{ matrix.nginx_version }},mode=max
-          platforms: linux/amd64
+          cache-from: type=gha,scope=${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }},mode=max
+          cache-to: type=gha,scope=${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }},mode=max
+          # platforms: linux/${{ steps.arch.outputs.arch }}
           provenance: mode=max
           sbom: true
           target: export
@@ -86,9 +92,9 @@ jobs:
 
       - name: Compress output
         run: |
-          tar -czf linux-amd64-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.tgz -C out/ ngx_http_opentracing_module.so
-          cp out/provenance.json linux-amd64-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.provenance.json
-          cp out/sbom.spdx.json linux-amd64-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.sbom.spdx.json
+          tar -czf linux-${{ steps.arch.outputs.arch }}-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.tgz -C out/ ngx_http_opentracing_module.so
+          cp out/provenance.json linux-${{ steps.arch.outputs.arch }}-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.provenance.json
+          cp out/sbom.spdx.json linux-${{ steps.arch.outputs.arch }}-nginx-${{ matrix.nginx_version }}-ngx_http_module.so.sbom.spdx.json
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
           tags: ${{ matrix.nginx_version }}
           cache-from: type=gha,scope=${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }},mode=max
           cache-to: type=gha,scope=${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }},mode=max
-          # platforms: linux/${{ steps.arch.outputs.arch }}
           provenance: mode=max
           sbom: true
           target: export

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           push: false
           file: build/Dockerfile
           tags: ${{ matrix.nginx_version }}
-          cache-from: type=gha,scope=${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }},mode=max
+          cache-from: type=gha,scope=${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }}
           cache-to: type=gha,scope=${{ matrix.nginx_version }}-${{ steps.arch.outputs.arch }},mode=max
           provenance: mode=max
           sbom: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Get architecture
         id: arch
         run: |
-          if [ "$(uname -m)" = "x86_64" ]; then echo "arch=amd64" >> $GITHUB_OUTPUT; else echo "arch=arm64" >> "$GITHUB_OUTPUT"; fi
+          if [ "$(uname -m)" = "x86_64" ]; then echo "arch=amd64" >> "$GITHUB_OUTPUT"; else echo "arch=arm64" >> "$GITHUB_OUTPUT"; fi
 
       - name: Build binary
         uses: docker/build-push-action@v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,62 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.ref_name }}-lint
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # checks:
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+  #     - name: Mise
+  #       uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+  #     - name: Install dependencies
+  #       run: |
+  #         yarn install
+
+  #     - name: Run lint
+  #       run: |
+  #         mise run lint --no-progress
+
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+        with:
+          actionlint_flags: -shellcheck ""
+
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
+        with:
+          config: .markdownlint-cli2.yaml
+          globs: '**/*.md'
+          fix: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
 
-      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+      - uses: reviewdog/action-actionlint@v1
         with:
           actionlint_flags: -shellcheck ""
 
@@ -53,9 +53,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
 
-      - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
+      - uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           config: .markdownlint-cli2.yaml
           globs: '**/*.md'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to run builds on both x86_64 and ARM runners, expanding platform support.
  * Build pipeline now detects target architecture to produce and publish architecture-labelled artifacts; cache keys and artifact names scoped per-architecture.
  * New lint workflow added to CI (actionlint and markdown-lint), with concurrency control and tightened workflow permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->