### PR TITLE
Remove date from trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_OS=debian
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0 AS xx
 
 ### Build base image for debian
-FROM --platform=$BUILDPLATFORM debian:trixie-20260610 AS build-base-debian
+FROM --platform=$BUILDPLATFORM debian:trixie AS build-base-debian
 
 RUN apt-get update \
     && apt-get install --no-install-recommends --no-install-suggests -y \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-20260610 AS base
+FROM debian:trixie AS base
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Docker base image to use the rolling Debian Trixie tag instead of the previously pinned date-specific version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->