### PR TITLE
Add null checks for ngx_http_add_variable() return values (opentracing_variable.cpp )

### DIFF
--- a/opentracing/src/opentracing_variable.cpp
+++ b/opentracing/src/opentracing_variable.cpp
@@ -105,6 +105,9 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   auto opentracing_context_var = ngx_http_add_variable(
       cf, &opentracing_context,
       NGX_HTTP_VAR_NOCACHEABLE | NGX_HTTP_VAR_NOHASH | NGX_HTTP_VAR_PREFIX);
+  if (opentracing_context_var == nullptr) {
+      return NGX_ERROR;
+  }
   opentracing_context_var->get_handler = expand_opentracing_context_variable;
   opentracing_context_var->data = 0;
 
@@ -112,6 +115,10 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
       to_ngx_str(opentracing_binary_context_variable_name);
   auto opentracing_binary_context_var = ngx_http_add_variable(
       cf, &opentracing_binary_context, NGX_HTTP_VAR_NOCACHEABLE);
+  if (opentracing_binary_context_var == nullptr) {
+    return NGX_ERROR;
+  }
+
   opentracing_binary_context_var->get_handler =
       expand_opentracing_binary_context_variable;
   opentracing_binary_context_var->data = 0;

--- a/opentracing/src/opentracing_variable.cpp
+++ b/opentracing/src/opentracing_variable.cpp
@@ -106,6 +106,7 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
       cf, &opentracing_context,
       NGX_HTTP_VAR_NOCACHEABLE | NGX_HTTP_VAR_NOHASH | NGX_HTTP_VAR_PREFIX);
   if (opentracing_context_var == nullptr) {
+      ngx_log_error(NGX_LOG_ERR, cf->log, 0, "Failed to add variable: %V", &opentracing_context);
       return NGX_ERROR;
   }
   opentracing_context_var->get_handler = expand_opentracing_context_variable;
@@ -116,7 +117,8 @@ ngx_int_t add_variables(ngx_conf_t* cf) noexcept {
   auto opentracing_binary_context_var = ngx_http_add_variable(
       cf, &opentracing_binary_context, NGX_HTTP_VAR_NOCACHEABLE);
   if (opentracing_binary_context_var == nullptr) {
-    return NGX_ERROR;
+      ngx_log_error(NGX_LOG_ERR, cf->log, 0, "Failed to add variable: %V", &opentracing_binary_context);
+      return NGX_ERROR;
   }
 
   opentracing_binary_context_var->get_handler =


### PR DESCRIPTION
Fixes #669

Added null checks for return values of `ngx_http_add_variable()` to prevent potential null pointer dereference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable initialization by adding validation checks to ensure variable creation succeeds before setting handlers and related data. If creation fails (including binary-context variable setup), the system now exits with an error instead of continuing with incomplete initialization, reducing the risk of runtime failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->