### PR TITLE
Use renovate to keep Makefile up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-NGINX_VERSION=$(shell grep -m1 'FROM nginx:' <Dockerfile | awk -F'[: ]' '{print $$3}')
+# renovate: datasource=docker depName=nginx
+NGINX_VERSION=1.31.2
 
 .PHONY: docker-image
 docker-image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the NGINX version to 1.31.2 for more predictable builds.
  * Added automated tracking for future NGINX version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->